### PR TITLE
Adding PPV1 and PPV2 values

### DIFF
--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -51,6 +51,8 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
                 inverterdata.update({"Instantaneous Battery I/O": invertor["powerdata"]["pbat"]})
                 inverterdata.update({"Instantaneous Grid I/O Total": invertor["powerdata"]["pmeter_l1"] + invertor["powerdata"]["pmeter_l2"] + invertor["powerdata"]["pmeter_l3"]})
                 inverterdata.update({"Instantaneous Load": invertor["powerdata"]["ppv1"] + invertor["powerdata"]["ppv2"] + invertor["powerdata"]["pmeter_dc"] + invertor["powerdata"]["pbat"] + invertor["powerdata"]["pmeter_l1"] + invertor["powerdata"]["pmeter_l2"] + invertor["powerdata"]["pmeter_l3"] })
+                inverterdata.update({"Instantaneous PPV1": invertor["powerdata"]["ppv1"]})
+                inverterdata.update({"Instantaneous PPV2": invertor["powerdata"]["ppv2"]})
                 self.data.update({invertor["sys_sn"]: inverterdata})
             return self.data
         except (

--- a/custom_components/alphaess/enums.py
+++ b/custom_components/alphaess/enums.py
@@ -27,4 +27,3 @@ class AlphaESSNames(str, Enum):
     Load = "Instantaneous Load"
     PPV1 = "Instantaneous PPV1"
     PPV2 = "Instantaneous PPV2"
-

--- a/custom_components/alphaess/enums.py
+++ b/custom_components/alphaess/enums.py
@@ -25,4 +25,6 @@ class AlphaESSNames(str, Enum):
     BatteryIO = "Instantaneous Battery I/O"
     GridIOTotal = "Instantaneous Grid I/O Total"
     Load = "Instantaneous Load"
+    PPV1 = "Instantaneous PPV1"
+    PPV2 = "Instantaneous PPV2"
 

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -150,6 +150,20 @@ SENSOR_DESCRIPTIONS: List[AlphaESSSensorDescription] = [
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+        AlphaESSSensorDescription(
+        key=AlphaESSNames.PPV1,
+        name="Instantaneous PPV1",
+        native_unit_of_measurement=POWER_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+        AlphaESSSensorDescription(
+        key=AlphaESSNames.PPV2,
+        name="Instantaneous PPV2",
+        native_unit_of_measurement=POWER_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 ]
 
 async def async_setup_entry(hass, entry, async_add_entities) -> None:


### PR DESCRIPTION
PPV1 and PPV2 values are the MPPT inputs per solar string. The values enable you to compare power produced from a north string vs east string for example

![image](https://user-images.githubusercontent.com/982535/187827221-d3395fbc-8217-48e1-aa8c-f51735b0b96f.png)
