### PR TITLE
reorg data extraction to prevent NoneType exceptions

### DIFF
--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -41,53 +41,53 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
                     _onedateenergy = invertor.get("OneDateEnergy", {})
                     # data from last power data API
                     _powerdata = invertor.get("LastPower", {})
-                    _gridpowerdetails = _powerdata.get("pgridDetail",{})
-                    _pvpowerdetails = _powerdata.get("ppvDetail",{})
-
-                    _pv =  _onedateenergy.get("epv")
-                    _feedin = _onedateenergy.get("eOutput")
-                    _gridcharge = _onedateenergy.get("eGridCharge")
-                    _charge = _onedateenergy.get("eCharge")
-                    _soc = _powerdata.get("soc")
                     
                     if _sumdata != None:
                     #   Still will keep in, but will be provided with the timezone difference
                         inverterdata.update({"Total Load": _sumdata.get("eload")})
-
-                    if _charge != None and _gridcharge != None:
-                        inverterdata.update({"Solar to Battery": _charge - _gridcharge})
-
-                    if _pv != None and _feedin != None:
-                        inverterdata.update({"Solar to Load": _pv - _feedin})
                     
-                    if _gridcharge != None:
-                        inverterdata.update({"Grid to Battery": _gridcharge})
-
                     if _onedateenergy != None:
-                        inverterdata.update({"EV Charger": _onedateenergy.get("eChargingPile")})
+                        _pv =  _onedateenergy.get("epv")
+                        _feedin = _onedateenergy.get("eOutput")
+                        _gridcharge = _onedateenergy.get("eGridCharge")
+                        _charge = _onedateenergy.get("eCharge")
+
+                        if _pv != None and _feedin != None:
+                            inverterdata.update({"Solar to Load": _pv - _feedin})
+
+                        if _charge != None and _gridcharge != None:
+                            inverterdata.update({"Solar to Battery": _charge - _gridcharge})
+
+                        if _gridcharge != None:
+                            inverterdata.update({"Grid to Battery": _gridcharge})
+
                         inverterdata.update({"Solar Production": _onedateenergy.get("epv")})
                         inverterdata.update({"Grid to Load": _onedateenergy.get("eInput")})
-                        inverterdata.update({"Charge": _onedateenergy.get("eCharge")})
+                        inverterdata.update({"Charge": _onedateenergy.get("echarge")})
                         inverterdata.update({"Discharge": _onedateenergy.get("eDischarge")})
-                        inverterdata.update({"Solar to Grid": _onedateenergy.get("eOutput")})
+                        inverterdata.update({"Solar to Grid": _onedateenergy.get("eOutput")})              
+
+                        inverterdata.update({"EV Charger": _onedateenergy.get("eChargingPile")})           
 
                     if _powerdata != None:                         
+                        _soc = _powerdata.get("soc")
+                        _gridpowerdetails = _powerdata.get("pgridDetail",{})
+                        _pvpowerdetails = _powerdata.get("ppvDetail",{})
+
+                        if _soc != None:
+                            inverterdata.update({"Instantaneous Battery SOC": _soc})
+                            inverterdata.update({"State of Charge": _soc})
+
                         inverterdata.update({"Instantaneous Generation": _powerdata.get("ppv")})
+                        inverterdata.update({"Instantaneous Battery I/O": _powerdata.get("pbat")})
+                        inverterdata.update({"Instantaneous Grid I/O Total": _powerdata.get("pgrid")})
+                        inverterdata.update({"Instantaneous Load": _powerdata.get("pload")})
 
                     if _pvpowerdetails != None:
                         inverterdata.update({"Instantaneous PPV1": _pvpowerdetails.get("ppv1")})
                         inverterdata.update({"Instantaneous PPV2": _pvpowerdetails.get("ppv2")})
                         inverterdata.update({"Instantaneous PPV3": _pvpowerdetails.get("ppv3")})
                         inverterdata.update({"Instantaneous PPV4": _pvpowerdetails.get("ppv4")})
-
-                    if _soc != None:
-                        inverterdata.update({"Instantaneous Battery SOC": _soc})
-                        inverterdata.update({"State of Charge": _soc})
-
-                    if _powerdata != None:
-                        inverterdata.update({"Instantaneous Battery I/O": _powerdata.get("pbat")})
-                        inverterdata.update({"Instantaneous Grid I/O Total": _powerdata.get("pgrid")})
-                        inverterdata.update({"Instantaneous Load": _powerdata.get("pload")})
 
                     if _gridpowerdetails != None:
                         inverterdata.update({"Instantaneous Grid I/O L1": _gridpowerdetails.get("pmeterL1")})

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -61,11 +61,12 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
                         if _gridcharge != None:
                             inverterdata.update({"Grid to Battery": _gridcharge})
 
-                        inverterdata.update({"Solar Production": _onedateenergy.get("epv")})
+                        inverterdata.update({"Solar Production": _pv})
+                        inverterdata.update({"Charge": _charge})
+                        inverterdata.update({"Solar to Grid": _feedin})              
+
                         inverterdata.update({"Grid to Load": _onedateenergy.get("eInput")})
-                        inverterdata.update({"Charge": _onedateenergy.get("echarge")})
                         inverterdata.update({"Discharge": _onedateenergy.get("eDischarge")})
-                        inverterdata.update({"Solar to Grid": _onedateenergy.get("eOutput")})              
 
                         inverterdata.update({"EV Charger": _onedateenergy.get("eChargingPile")})           
 

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -52,20 +52,15 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
                         _gridcharge = _onedateenergy.get("eGridCharge")
                         _charge = _onedateenergy.get("eCharge")
 
-                        if _pv != None and _feedin != None:
-                            inverterdata.update({"Solar to Load": _pv - _feedin})
-
-                        if _charge != None and _gridcharge != None:
-                            inverterdata.update({"Solar to Battery": _charge - _gridcharge})
-
-                        if _gridcharge != None:
-                            inverterdata.update({"Grid to Battery": _gridcharge})
-
                         inverterdata.update({"Solar Production": _pv})
-                        inverterdata.update({"Charge": _charge})
+                        inverterdata.update({"Solar to Load": _pv - _feedin})
                         inverterdata.update({"Solar to Grid": _feedin})              
+                        inverterdata.update({"Solar to Battery": _charge - _gridcharge})
 
                         inverterdata.update({"Grid to Load": _onedateenergy.get("eInput")})
+                        inverterdata.update({"Grid to Battery": _gridcharge})
+
+                        inverterdata.update({"Charge": _charge})
                         inverterdata.update({"Discharge": _onedateenergy.get("eDischarge")})
 
                         inverterdata.update({"EV Charger": _onedateenergy.get("eChargingPile")})           
@@ -75,22 +70,22 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
                         _gridpowerdetails = _powerdata.get("pgridDetail",{})
                         _pvpowerdetails = _powerdata.get("ppvDetail",{})
 
-                        if _soc != None:
-                            inverterdata.update({"Instantaneous Battery SOC": _soc})
-                            inverterdata.update({"State of Charge": _soc})
+                        # wonder why do we have this twice
+                        inverterdata.update({"Instantaneous Battery SOC": _soc})
+                        inverterdata.update({"State of Charge": _soc})
 
-                        inverterdata.update({"Instantaneous Generation": _powerdata.get("ppv")})
                         inverterdata.update({"Instantaneous Battery I/O": _powerdata.get("pbat")})
-                        inverterdata.update({"Instantaneous Grid I/O Total": _powerdata.get("pgrid")})
                         inverterdata.update({"Instantaneous Load": _powerdata.get("pload")})
 
-                    if _pvpowerdetails != None:
+                        inverterdata.update({"Instantaneous Generation": _powerdata.get("ppv")})
+                        # pv power generation details
                         inverterdata.update({"Instantaneous PPV1": _pvpowerdetails.get("ppv1")})
                         inverterdata.update({"Instantaneous PPV2": _pvpowerdetails.get("ppv2")})
                         inverterdata.update({"Instantaneous PPV3": _pvpowerdetails.get("ppv3")})
                         inverterdata.update({"Instantaneous PPV4": _pvpowerdetails.get("ppv4")})
 
-                    if _gridpowerdetails != None:
+                        inverterdata.update({"Instantaneous Grid I/O Total": _powerdata.get("pgrid")})
+                        # grid power usage details
                         inverterdata.update({"Instantaneous Grid I/O L1": _gridpowerdetails.get("pmeterL1")})
                         inverterdata.update({"Instantaneous Grid I/O L2": _gridpowerdetails.get("pmeterL2")})
                         inverterdata.update({"Instantaneous Grid I/O L3": _gridpowerdetails.get("pmeterL3")})


### PR DESCRIPTION
Reorganised the extraction of the json response values to prevent the NoneType exceptions that occur at midnight local time.

```
2023-11-22 00:03:14.647 ERROR (MainThread) [custom_components.alphaess] Unexpected error fetching alphaess data: 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 290, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/alphaess/coordinator.py", line 45, in _async_update_data
    _pv =  _onedateenergy.get("epv")
           ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```