### PR TITLE
Update default value to None and improve multi-inverter experience

### DIFF
--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -111,7 +111,9 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
                     inverterdata["Instantaneous Battery SOC"] = _soc
 
                     if _onedatepower and _soc == 0:
-                        inverterdata["State of Charge"] = await safe_get(_onedatepower[0], "cbat")
+                        first_entry = _onedatepower[0]
+                        _cbat = first_entry.get("cbat", None)
+                        inverterdata["State of Charge"] = _cbat
 
                     inverterdata["Instantaneous Battery I/O"] = await safe_get(_powerdata, "pbat")
                     inverterdata["Instantaneous Load"] = await safe_get(_powerdata, "pload")

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -112,8 +112,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
 
                     if _onedatepower and _soc == 0:
                         first_entry = _onedatepower[0]
-                        _cbat = first_entry.get("cbat", 0)
-                        inverterdata["State of Charge"] = _cbat
+                        inverterdata["State of Charge"] = await process_value(first_entry.get("cbat"))
 
                     inverterdata["Instantaneous Battery I/O"] = await safe_get(_powerdata, "pbat")
                     inverterdata["Instantaneous Load"] = await safe_get(_powerdata, "pload")

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -80,8 +80,8 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
 
                     inverterdata["Total Load"] = await safe_get(_sumdata, "eload")
                     inverterdata["Total Income"] = await safe_get(_sumdata, "totalIncome")
-                    inverterdata["Self Consumption"] = await safe_get(_sumdata, "eselfConsumption", default=0) * 100
-                    inverterdata["Self Sufficiency"] = await safe_get(_sumdata, "eselfSufficiency", default=0) * 100
+                    inverterdata["Self Consumption"] = await safe_get(_sumdata, "eselfConsumption") * 100
+                    inverterdata["Self Sufficiency"] = await safe_get(_sumdata, "eselfSufficiency") * 100
 
                     _pv = await safe_get(_onedateenergy, "epv")
                     _feedin = await safe_get(_onedateenergy, "eOutput")

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -111,8 +111,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
                     inverterdata["Instantaneous Battery SOC"] = _soc
 
                     if _onedatepower and _soc == 0:
-                        first_entry = _onedatepower[0]
-                        inverterdata["State of Charge"] = await process_value(first_entry.get("cbat"))
+                        inverterdata["State of Charge"] = await safe_get(_onedatepower[0], "cbat")
 
                     inverterdata["Instantaneous Battery I/O"] = await safe_get(_powerdata, "pbat")
                     inverterdata["Instantaneous Load"] = await safe_get(_powerdata, "pload")

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -80,8 +80,14 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
 
                     inverterdata["Total Load"] = await safe_get(_sumdata, "eload")
                     inverterdata["Total Income"] = await safe_get(_sumdata, "totalIncome")
-                    inverterdata["Self Consumption"] = await safe_get(_sumdata, "eselfConsumption") * 100
-                    inverterdata["Self Sufficiency"] = await safe_get(_sumdata, "eselfSufficiency") * 100
+
+                    self_data = {
+                        "Self Consumption": await safe_get(_sumdata, "eselfConsumption"),
+                        "Self Sufficiency": await safe_get(_sumdata, "eselfSufficiency")
+                    }
+
+                    for key, value in self_data.items():
+                        inverterdata[key] = value * 100 if value is not None else None
 
                     _pv = await safe_get(_onedateenergy, "epv")
                     _feedin = await safe_get(_onedateenergy, "eOutput")

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -43,24 +43,23 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
         self.has_throttle = True
         self.data: dict[str, dict[str, float]] = {}
         self.LOCAL_INVERTER_COUNT = 0
+        self.model_list = get_inverter_list()
+        self.inverter_count = get_inverter_count()
+
+        if "Storion-S5" not in self.model_list and len(self.model_list) > 0:
+            self.has_throttle = False
+            set_throttle_count_lower()
+
+        if self.inverter_count == 1:
+            self.LOCAL_INVERTER_COUNT = 0
+        else:
+            self.LOCAL_INVERTER_COUNT = self.inverter_count
 
     async def _async_update_data(self):
         """Update data via library."""
 
-        model_list = get_inverter_list()
-        inverter_count = get_inverter_count()
-
-        if "Storion-S5" not in model_list and len(model_list) > 0:
-            self.has_throttle = False
-            set_throttle_count_lower()
-
-        if inverter_count == 1:
-            LOCAL_INVERTER_COUNT = 0
-        else:
-            LOCAL_INVERTER_COUNT = inverter_count
-
         try:
-            jsondata = await self.api.getdata(self.has_throttle, THROTTLE_MULTIPLIER * LOCAL_INVERTER_COUNT)
+            jsondata = await self.api.getdata(self.has_throttle, THROTTLE_MULTIPLIER * self.LOCAL_INVERTER_COUNT)
             if jsondata is not None:
                 for invertor in jsondata:
 

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -7,7 +7,8 @@ from alphaess import alphaess
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, SCAN_INTERVAL, THROTTLE_MULTIPLIER, get_inverter_count, set_throttle_count_lower, get_inverter_list
+from .const import DOMAIN, SCAN_INTERVAL, THROTTLE_MULTIPLIER, get_inverter_count, set_throttle_count_lower, \
+    get_inverter_list
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -47,11 +48,12 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
 
         model_list = get_inverter_list()
+        inverter_count = get_inverter_count()
+
         if "Storion-S5" not in model_list and len(model_list) > 0:
             self.has_throttle = False
             set_throttle_count_lower()
 
-        inverter_count = get_inverter_count()
         if inverter_count == 1:
             LOCAL_INVERTER_COUNT = 0
         else:

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -103,9 +103,7 @@ class AlphaESSSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the resources."""
-        value = self._coordinator.data[self._serial][self._name]
-        if value is not None:
-            return value
+        return self._coordinator.data[self._serial][self._name]
 
     @property
     def native_unit_of_measurement(self):

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, increment_inverter_count, add_inverter_to_list
+from .const import DOMAIN
 from .coordinator import AlphaESSDataUpdateCoordinator
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -39,8 +39,6 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
     for serial, data in coordinator.data.items():
         model = data.get("Model")
         _LOGGER.info(f"Serial: {serial}, Model: {model}")
-        add_inverter_to_list(model)
-        increment_inverter_count()
 
         if model == "Storion-S5":
             for description in limited_key_supported_states:

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -35,7 +35,7 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
         description.key: description for description in LIMITED_SENSOR_DESCRIPTIONS
     }
 
-    _LOGGER.info(f"INITIALIZING DEVICES")
+    _LOGGER.info(f"Initializing Inverters")
     for serial, data in coordinator.data.items():
         model = data.get("Model")
         _LOGGER.info(f"Serial: {serial}, Model: {model}")

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -103,7 +103,9 @@ class AlphaESSSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the resources."""
-        return self._coordinator.data[self._serial][self._name]
+        value = self._coordinator.data[self._serial][self._name]
+        if value is not None:
+            return value
 
     @property
     def native_unit_of_measurement(self):

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -87,6 +87,7 @@ class AlphaESSSensor(CoordinatorEntity, SensorEntity):
                     identifiers={(DOMAIN, serial)},
                     manufacturer="AlphaESS",
                     model=coordinator.data[invertor]["Model"],
+                    model_id=self._serial,
                     name=f"Alpha ESS Energy Statistics : {serial}",
                 )
 

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -67,14 +67,17 @@ class AlphaESSSensor(CoordinatorEntity, SensorEntity):
         super().__init__(coordinator)
         self._config = config
         self._name = key_supported_states.name
-        self._native_unit_of_measurement = key_supported_states.native_unit_of_measurement
         self._entity_category = key_supported_states.entity_category
         self._icon = key_supported_states.icon
         self._device_class = key_supported_states.device_class
         self._state_class = key_supported_states.state_class
         self._serial = serial
-        self._currency = currency
         self._coordinator = coordinator
+
+        if key_supported_states.native_unit_of_measurement is CURRENCY_DOLLAR:
+            self._native_unit_of_measurement = currency
+        else:
+            self._native_unit_of_measurement = key_supported_states.native_unit_of_measurement
 
         for invertor in coordinator.data:
             serial = invertor.upper()
@@ -105,11 +108,7 @@ class AlphaESSSensor(CoordinatorEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self):
         """Return the native unit of measurement of the sensor."""
-        if self._native_unit_of_measurement is not CURRENCY_DOLLAR:
-            return self._native_unit_of_measurement
-        else:
-            self._native_unit_of_measurement = self._currency
-            return self._native_unit_of_measurement
+        return self._native_unit_of_measurement
 
     @property
     def device_class(self):

--- a/custom_components/alphaess/sensorlist.py
+++ b/custom_components/alphaess/sensorlist.py
@@ -173,14 +173,14 @@ FULL_SENSOR_DESCRIPTIONS: List[AlphaESSSensorDescription] = [
     ), AlphaESSSensorDescription(
         key=AlphaESSNames.SelfConsumption,
         name="Self Consumption",
-        icon="mdi:percent",
+        icon="mdi:home-percent",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=None,
     ), AlphaESSSensorDescription(
         key=AlphaESSNames.SelfSufficiency,
         name="Self Sufficiency",
-        icon="mdi:percent",
+        icon="mdi:home-percent",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=None,

--- a/custom_components/alphaess/sensorlist.py
+++ b/custom_components/alphaess/sensorlist.py
@@ -187,6 +187,7 @@ FULL_SENSOR_DESCRIPTIONS: List[AlphaESSSensorDescription] = [
     ), AlphaESSSensorDescription(
         key=AlphaESSNames.EmsStatus,
         name="EMS Status",
+        icon="mdi:home-battery",
         device_class=SensorDeviceClass.ENUM,
         state_class=None,
         entity_category=EntityCategory.DIAGNOSTIC
@@ -194,6 +195,7 @@ FULL_SENSOR_DESCRIPTIONS: List[AlphaESSSensorDescription] = [
     AlphaESSSensorDescription(
         key=AlphaESSNames.usCapacity,
         name="Maximum Battery Capacity",
+        icon="mdi:home-percent",
         native_unit_of_measurement=PERCENTAGE,
         state_class=None,
         entity_category=EntityCategory.DIAGNOSTIC
@@ -300,26 +302,28 @@ LIMITED_SENSOR_DESCRIPTIONS: List[AlphaESSSensorDescription] = [
     ), AlphaESSSensorDescription(
         key=AlphaESSNames.SelfConsumption,
         name="Self Consumption",
-        icon="mdi:percent",
+        icon="mdi:home-percent",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=None,
     ), AlphaESSSensorDescription(
         key=AlphaESSNames.SelfSufficiency,
         name="Self Sufficiency",
-        icon="mdi:percent",
+        icon="mdi:home-percent",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.POWER_FACTOR,
         state_class=None,
     ), AlphaESSSensorDescription(
         key=AlphaESSNames.EmsStatus,
         name="EMS Status",
+        icon="mdi:home-battery",
         device_class=SensorDeviceClass.ENUM,
         state_class=None,
         entity_category=EntityCategory.DIAGNOSTIC
     ), AlphaESSSensorDescription(
         key=AlphaESSNames.usCapacity,
         name="Maximum Battery Capacity",
+        icon="mdi:home-percent",
         native_unit_of_measurement=PERCENTAGE,
         state_class=None,
         entity_category=EntityCategory.DIAGNOSTIC


### PR DESCRIPTION
- Fix for https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/127 - By setting the default value to None, and then checking the following calculations to None (if one of the two is None, that means the API has not returned the data, or the datatype is not supported (like in the case of Storion-S5 inverters). then introduce a check within the native_value() to see if the state is None, if not, return the value. this in theory will just not update the state of the sensor for any None values

This will be shown in the logbook by the EMS staus going from Normal to unavailable 
![image](https://github.com/user-attachments/assets/c0856f08-3645-461e-8888-b8f076e723dd)


- Moved increment_inverter_count, add_inverter_to_list to pre-startup checks, this gets the list of inverters before the coordinator is called, meaning the amount of inverters an account has is done before the first .getdata is called (remove the chance of error logging in the first API call)

- Add system serial number to device page 
![image](https://github.com/user-attachments/assets/82b9c2d0-8b97-47ab-86b2-b5a047ffdb59)

- Updated the icons for the self-percentage based sensors and EMS status
![image](https://github.com/user-attachments/assets/ae8ae0eb-adc2-4ee5-b070-4632172f459f)
![image](https://github.com/user-attachments/assets/7f836a1f-c801-4dad-8c91-8061352190cc)





Closes https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/131
Closes https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/132
Closes https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/127
Closes https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/129