### PR TITLE
Allow SSL verify bypass

### DIFF
--- a/custom_components/alphaess/config_flow.py
+++ b/custom_components/alphaess/config_flow.py
@@ -18,14 +18,15 @@ from .const import DOMAIN, add_inverter_to_list, increment_inverter_count
 STEP_USER_DATA_SCHEMA = vol.Schema({
     vol.Required("AppID", description="AppID"): str,
     vol.Required("AppSecret", description="AppSecret"): str,
-    vol.Optional("IPAddress", default='0'): vol.Any(None, str)
+    vol.Optional("IPAddress", default='0'): vol.Any(None, str),
+    vol.Optional("Verify SSL Certificate", default=True): bool
 })
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
 
-    client = alphaess.alphaess(data["AppID"], data["AppSecret"], ipaddress=data["IPAddress"])
+    client = alphaess.alphaess(data["AppID"], data["AppSecret"], ipaddress=data["IPAddress"], verify_ssl=data["Verify SSL Certificate"])
 
     try:
         await client.authenticate()
@@ -116,7 +117,14 @@ class AlphaESSOptionsFlowHandler(config_entries.OptionsFlow):
                     "IPAddress",
                     self._config_entry.data.get("IPAddress", ""),
                 ),
-            ): str
+            ): str,
+            vol.Optional(
+                "Verify SSL Certificate",
+                default=self._config_entry.options.get(
+                    "Verify SSL Certificate",
+                    self._config_entry.data.get("Verify SSL Certificate", True),
+                ),
+            ): bool
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema))

--- a/custom_components/alphaess/manifest.json
+++ b/custom_components/alphaess/manifest.json
@@ -13,9 +13,9 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/CharlesGillanders/homeassistant-alphaESS/issues",
   "requirements": [
-    "alphaessopenapi==0.0.15"
+    "alphaessopenapi==0.0.17"
   ],
-  "version": "0.7.1"
+  "version": "0.7.2"
 }
 
 

--- a/custom_components/alphaess/translations/en.json
+++ b/custom_components/alphaess/translations/en.json
@@ -7,7 +7,8 @@
         "data": {
           "AppID": "AppID",
           "AppSecret": "AppSecret",
-          "IPAddress": "Inverter IP address (optional, 0 to disable)"
+          "IPAddress": "Inverter IP address (optional, 0 to disable)",
+          "Verify SSL Certificate": "Verify SSL Certificate"
         }
       }
     },
@@ -24,7 +25,8 @@
     "step": {
       "init": {
         "data": {
-          "IPAddress": "Inverter IP address (optional, 0 to disable)"
+        "IPAddress": "Inverter IP address (optional, 0 to disable)",
+        "Verify SSL Certificate": "Verify SSL Certificate"
         }
       }
     }


### PR DESCRIPTION
- Bump alphaessopenapi to 0.0.17
- Bump integration version to 0.7.2
- Allow no verify SSL Cert on new entry, or existing entries via the options flow 

requires https://github.com/CharlesGillanders/alphaess-openAPI/pull/21 to be pushed to pypi

fixes #204 