### PR TITLE
bump to v0.7.5 to align with GitHub releases

### DIFF
--- a/custom_components/alphaess/manifest.json
+++ b/custom_components/alphaess/manifest.json
@@ -15,7 +15,7 @@
   "requirements": [
     "alphaessopenapi==0.0.17"
   ],
-  "version": "0.7.4"
+  "version": "0.7.5"
 }
 
 


### PR DESCRIPTION
Bump version to align with the next GitHub release (forgot that 0.7.4 was released lol) 