### PR TITLE
Add toggle for notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 /.idea
 custom_components/alphaess/__pycache__/
+.claude/settings.local.json

--- a/custom_components/alphaess/button.py
+++ b/custom_components/alphaess/button.py
@@ -139,18 +139,20 @@ class AlphaESSBatteryButton(CoordinatorEntity, ButtonEntity):
             if last_update is None or local_current_time - last_update >= rate_limit:
                 last_update_dict[self._serial] = local_current_time
                 await update_fn(update_key, self._serial, self._time)
-                await create_persistent_notification(
-                    self.hass,
-                    message=f"{movement_direction} command sent successfully for {self._serial}.",
-                    title=f"{self._serial} Battery Control",
-                )
+                if not self._config.options.get("Disable Notifications On Charge/Discharge Confirmation", self._config.data.get("Disable Notifications On Charge/Discharge Confirmation", True)):
+                    await create_persistent_notification(
+                        self.hass,
+                        message=f"{movement_direction} command sent successfully for {self._serial}.",
+                        title=f"{self._serial} Battery Control",
+                    )
             else:
                 remaining_time = rate_limit - (local_current_time - last_update)
                 minutes, seconds = divmod(remaining_time.total_seconds(), 60)
 
-                await create_persistent_notification(self.hass,
-                                                     message=f"Please wait {int(minutes)} minutes and {int(seconds)} seconds.",
-                                                     title=f"{self._serial} cannot call {movement_direction}")
+                if not self._config.options.get("Disable Notifications On Charge/Discharge Confirmation", self._config.data.get("Disable Notifications On Charge/Discharge Confirmation", True)):
+                    await create_persistent_notification(self.hass,
+                                                         message=f"Please wait {int(minutes)} minutes and {int(seconds)} seconds.",
+                                                         title=f"{self._serial} cannot call {movement_direction}")
 
         current_time = datetime.now(timezone.utc)
 
@@ -161,11 +163,12 @@ class AlphaESSBatteryButton(CoordinatorEntity, ButtonEntity):
                         self._serial] >= rate_limit):
                 last_discharge_update[self._serial] = last_charge_update[self._serial] = current_time
                 await self._coordinator.reset_config(self._serial)
-                await create_persistent_notification(
-                    self.hass,
-                    message=f"Charge/discharge configuration reset successfully for {self._serial}.",
-                    title=f"{self._serial} Battery Control",
-                )
+                if not self._config.options.get("Disable Notifications On Charge/Discharge Confirmation", self._config.data.get("Disable Notifications On Charge/Discharge Confirmation", True)):
+                    await create_persistent_notification(
+                        self.hass,
+                        message=f"Charge/discharge configuration reset successfully for {self._serial}.",
+                        title=f"{self._serial} Battery Control",
+                    )
             else:
                 await handle_time_restriction(last_charge_update, self._coordinator.update_charge,
                                               "charge", self._movement_state)

--- a/custom_components/alphaess/config_flow.py
+++ b/custom_components/alphaess/config_flow.py
@@ -19,7 +19,8 @@ STEP_USER_DATA_SCHEMA = vol.Schema({
     vol.Required("AppID", description="AppID"): str,
     vol.Required("AppSecret", description="AppSecret"): str,
     vol.Optional("IPAddress", default=''): str,
-    vol.Optional("Verify SSL Certificate", default=True): bool
+    vol.Optional("Verify SSL Certificate", default=True): bool,
+    vol.Optional("Disable Notifications On Charge/Discharge Confirmation", default=True): bool,
 })
 
 
@@ -157,7 +158,14 @@ class AlphaESSOptionsFlowHandler(config_entries.OptionsFlow):
                     "Verify SSL Certificate",
                     self._config_entry.data.get("Verify SSL Certificate", True),
                 ),
-            ): bool
+            ): bool,
+            vol.Optional(
+                "Disable Notifications On Charge/Discharge Confirmation",
+                default=self._config_entry.options.get(
+                    "Disable Notifications On Charge/Discharge Confirmation",
+                    self._config_entry.data.get("Disable Notifications On Charge/Discharge Confirmation", True),
+                ),
+            ): bool,
         }
 
         return self.async_show_form(step_id="init", data_schema=vol.Schema(schema), errors=errors)

--- a/custom_components/alphaess/manifest.json
+++ b/custom_components/alphaess/manifest.json
@@ -15,7 +15,7 @@
   "requirements": [
     "alphaessopenapi==0.0.17"
   ],
-  "version": "0.7.5"
+  "version": "0.7.6"
 }
 
 


### PR DESCRIPTION
- Add toggle on config flow for new setups, and within the options flow for existing integrations to enable/disable notifications on successful charge/discharge calls 
- Bump to 0.7.6

Notifications are disabled by default on new setups, and existing setups it can be disabled by going to the o0ptions flow

fixes #226 