### PR TITLE
Fix entity IDs missing serial number prefix on new installations    

### DIFF
--- a/custom_components/alphaess/button.py
+++ b/custom_components/alphaess/button.py
@@ -268,5 +268,10 @@ class AlphaESSBatteryButton(CoordinatorEntity, ButtonEntity):
         return f"{self._name}"
 
     @property
+    def suggested_object_id(self):
+        """Return suggested object id."""
+        return f"{self._serial} {self._name}"
+
+    @property
     def icon(self):
         return self._icon

--- a/custom_components/alphaess/manifest.json
+++ b/custom_components/alphaess/manifest.json
@@ -15,7 +15,7 @@
   "requirements": [
     "alphaessopenapi==0.0.17"
   ],
-  "version": "0.8.1"
+  "version": "0.8.2"
 }
 
 

--- a/custom_components/alphaess/number.py
+++ b/custom_components/alphaess/number.py
@@ -202,6 +202,11 @@ class AlphaNumber(CoordinatorEntity, RestoreNumber):
         return f"{self._name}"
 
     @property
+    def suggested_object_id(self):
+        """Return suggested object id."""
+        return f"{self._serial} {self._name}"
+
+    @property
     def mode(self):
         return "box"
 
@@ -266,6 +271,11 @@ class AlphaEVNumber(CoordinatorEntity, NumberEntity):
     @property
     def name(self):
         return f"{self._name}"
+
+    @property
+    def suggested_object_id(self):
+        """Return suggested object id."""
+        return f"{self._serial} {self._name}"
 
     @property
     def native_unit_of_measurement(self):

--- a/custom_components/alphaess/sensor.py
+++ b/custom_components/alphaess/sensor.py
@@ -251,6 +251,11 @@ class AlphaESSSensor(CoordinatorEntity, SensorEntity):
         return f"{self._name}"
 
     @property
+    def suggested_object_id(self):
+        """Return suggested object id."""
+        return f"{self._serial} {self._name}"
+
+    @property
     def available(self) -> bool:
         """Return if entity is available based on whether its key exists in the data."""
         if not self.coordinator.last_update_success:


### PR DESCRIPTION
 Fixes #233 

- New integrations set up via the config flow were
  generating entity IDs without the inverter serial
  number (e.g. button.15_minute_charge instead of
  button.al7011023030271_15_minute_charge). This made it
   difficult to identify which device a sensor belongs
  to, especially in multi-inverter setups.

 - Adds suggested_object_id to all entity classes so HA
  includes the serial prefix in the entity ID at
  creation time, without changing the friendly display
  name. all existing installs can recreate entity ID's to the new schema 
  
  
<img width="789" height="306" alt="image" src="https://github.com/user-attachments/assets/0191d4f4-ca62-47c7-a69e-0cac4c735095" />

