### PR TITLE
Fix EV Charger: allow to charge ev when in finishing mode

### DIFF
--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -417,7 +417,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator):
             return False
 
         if direction == 1:
-            return status in (2, 4, 5)
+            return status in (2, 4, 5, 6)
         if direction == 0:
             return status in (3, 4, 5)
         return False


### PR DESCRIPTION
The coordinator did not allow a charge command when the EV charger was in mode "6" (finishing). This is however not consistent with app behavior where the charging can be started again if the charger was in finishing mode.