### PR TITLE
Write charge/discharge schedules to the periodic API as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Two things to be aware of:
   periodic one rejects it. If your slots overlap the periodic write is skipped, a warning is
   logged, and only the legacy endpoint is written — which on a migrated server means the change
   will not take effect. Adjust the periods so they do not overlap.
+- **You need at least one charge period *and* one discharge period.** `setTimeChargeBySn`
+  rejects an empty list (`6001 "time list is null"`) and a missing one (`10001`), and has no
+  representation for "no periods on this side", so when either list would be empty the periodic
+  write is skipped and only the legacy endpoints are written. For the same reason the
+  *Reset Charge/Discharge* button cannot clear a periodic schedule — do that in the AlphaESS app.
 
 ### EV charger controls
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,17 @@ So every charge/discharge change is written to **both**: the periodic API
 the integration checks once per inverter whether the periodic API is available for your system,
 and quietly skips it if your account is not entitled to it (return code `6017`).
 
+Each inverter gets a **Scheduling API** diagnostic sensor showing which one applies to you:
+
+| Value | Meaning |
+| --- | --- |
+| `periodic` | Your system is on the newer backend. Both APIs are written. |
+| `legacy` | Your system only accepts the old endpoints, and only those are written. |
+| `unknown` | The check hasn't returned an answer yet; it retries on each full poll. |
+
+It's also included in the integration's downloadable diagnostics, so it's worth attaching that
+to any bug report about charge/discharge times not applying.
+
 Two things to be aware of:
 
 - **A weekly schedule set in the AlphaESS app will be flattened to a daily one.** The integration

--- a/README.md
+++ b/README.md
@@ -70,30 +70,35 @@ The current charge config, discharge config and charging range will only update 
 
 ### Which scheduling API gets written
 
-AlphaESS has migrated some regions (UK, AUS/NZ) to a backend that only acts on its newer
-*periodic* schedule API. On those servers the older `updateChargeConfigInfo` /
-`updateDisChargeConfigInfo` endpoints still answer OK, but the inverter never applies the change
-until someone opens the AlphaESS app and presses Save
-([#267](https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/267)), or the command
-times out downstream entirely
-([#269](https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/269)). Other regions
+AlphaESS has migrated some systems to a backend that only acts on its newer *periodic* schedule
+API. On those, the older `updateChargeConfigInfo` / `updateDisChargeConfigInfo` endpoints still
+answer OK, but the inverter never applies the change until someone opens the AlphaESS app and
+presses Save ([#267](https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/267)), or
+the command times out downstream entirely
+([#269](https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/269)). Other systems
 still only understand the older endpoints.
 
-So every charge/discharge change is written to **both**: the periodic API
-(`setTimeChargeBySn`) first, then the legacy endpoints. No configuration is needed — on startup
-the integration checks once per inverter whether the periodic API is available for your system,
-and quietly skips it if your account is not entitled to it (return code `6017`).
+So every charge/discharge change is written to **both**, always: the periodic API
+(`setTimeChargeBySn`) first, then the legacy endpoints. Nothing to configure.
 
-Each inverter gets a **Scheduling API** diagnostic sensor showing which one applies to you:
+Deliberately, this is *not* conditional on detecting which backend you are on. The obvious check —
+reading the periodic schedule with `getTimeChargeBySn` — doesn't answer that question: it is
+separately permissioned and returns `6017` on plenty of accounts whose systems are on the new
+backend. Gating the write on it would skip the write for exactly the people this is meant to fix.
+The cost of always writing both is one extra API call per change.
+
+Each inverter has a **Periodic Schedule Read** diagnostic sensor, which reports only whether that
+read works on your account:
 
 | Value | Meaning |
 | --- | --- |
-| `periodic` | Your system is on the newer backend. Both APIs are written. |
-| `legacy` | Your system only accepts the old endpoints, and only those are written. |
-| `unknown` | The check hasn't returned an answer yet; it retries on each full poll. |
+| `readable` | `getTimeChargeBySn` returns your schedule. |
+| `unreadable` | The read is rejected, usually `6017`. |
+| `unknown` | No answer yet; retried on each full poll. |
 
-It's also included in the integration's downloadable diagnostics, so it's worth attaching that
-to any bug report about charge/discharge times not applying.
+`unreadable` does **not** mean your system is on the old backend, and it does not stop the
+periodic write. It is a diagnostic only. The value is also in the integration's downloadable
+diagnostics, which is worth attaching to any report about charge/discharge times not applying.
 
 Two things to be aware of:
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ separately permissioned and returns `6017` on plenty of accounts whose systems a
 backend. Gating the write on it would skip the write for exactly the people this is meant to fix.
 The cost of always writing both is one extra API call per change.
 
+If the periodic write comes back `6017` ("no operation permissions"), that's the API saying this
+system can't use the feature at all. It's permanent, so the integration stops attempting it for
+that inverter and writes only the legacy endpoints from then on.
+
 Each inverter has a **Periodic Schedule Read** diagnostic sensor, which reports only whether that
 read works on your account:
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,33 @@ An error will be placed in the logs
 
 The current charge config, discharge config and charging range will only update once the API is re-called (can be up to 1 min)
 
+### Which scheduling API gets written
+
+AlphaESS has migrated some regions (UK, AUS/NZ) to a backend that only acts on its newer
+*periodic* schedule API. On those servers the older `updateChargeConfigInfo` /
+`updateDisChargeConfigInfo` endpoints still answer OK, but the inverter never applies the change
+until someone opens the AlphaESS app and presses Save
+([#267](https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/267)), or the command
+times out downstream entirely
+([#269](https://github.com/CharlesGillanders/homeassistant-alphaESS/issues/269)). Other regions
+still only understand the older endpoints.
+
+So every charge/discharge change is written to **both**: the periodic API
+(`setTimeChargeBySn`) first, then the legacy endpoints. No configuration is needed — on startup
+the integration checks once per inverter whether the periodic API is available for your system,
+and quietly skips it if your account is not entitled to it (return code `6017`).
+
+Two things to be aware of:
+
+- **A weekly schedule set in the AlphaESS app will be flattened to a daily one.** The integration
+  writes daily schedules (`executeCycleType: 0`) so that the behaviour matches the two time slots
+  shown here. Per-weekday scheduling is not exposed by this integration; use Home Assistant
+  automations if you need different times on different days.
+- **Charge and discharge periods must not overlap.** The legacy endpoints allowed this, the
+  periodic one rejects it. If your slots overlap the periodic write is skipped, a warning is
+  logged, and only the legacy endpoint is written — which on a migrated server means the change
+  will not take effect. Adjust the periods so they do not overlap.
+
 ### EV charger controls
 
 The integration exposes EV charger controls (start/stop and current setting) when an EV charger is detected.

--- a/custom_components/alphaess/__init__.py
+++ b/custom_components/alphaess/__init__.py
@@ -205,8 +205,10 @@ def _cleanup_stale_ev_entities(
             ent_reg.async_remove(entity_entry.entity_id)
 
 
-def _resolve_client_for_serial(hass: HomeAssistant, serial: str) -> alphaess.alphaess:
-    """Find the API client managing the given inverter serial.
+def _resolve_coordinator_for_serial(
+    hass: HomeAssistant, serial: str
+) -> AlphaESSDataUpdateCoordinator:
+    """Find the coordinator managing the given inverter serial.
 
     Resolved at call time so services keep working across entry reloads.
     """
@@ -216,9 +218,9 @@ def _resolve_client_for_serial(hass: HomeAssistant, serial: str) -> alphaess.alp
         if not isinstance(coordinator, AlphaESSDataUpdateCoordinator):
             continue
         if serial in (coordinator.data or {}):
-            return coordinator.api
+            return coordinator
         if fallback is None:
-            fallback = coordinator.api
+            fallback = coordinator
     if fallback is not None:
         return fallback
     raise HomeAssistantError(
@@ -228,23 +230,31 @@ def _resolve_client_for_serial(hass: HomeAssistant, serial: str) -> alphaess.alp
 
 async def _async_service_battery_charge(call: ServiceCall) -> None:
     """Handle the setbatterycharge service."""
-    client = _resolve_client_for_serial(call.hass, call.data["serial"])
-    await client.updateChargeConfigInfo(
-        call.data["serial"], call.data["chargestopsoc"],
-        int(call.data["enabled"] is True), call.data["cp1end"],
-        call.data["cp2end"], call.data["cp1start"],
-        call.data["cp2start"],
+    serial = call.data["serial"]
+    coordinator = _resolve_coordinator_for_serial(call.hass, serial)
+    await coordinator.async_write_charge_config(
+        serial,
+        bat_high_cap=call.data["chargestopsoc"],
+        grid_charge=int(call.data["enabled"] is True),
+        times={
+            "timeChaf1": call.data["cp1start"], "timeChae1": call.data["cp1end"],
+            "timeChaf2": call.data["cp2start"], "timeChae2": call.data["cp2end"],
+        },
     )
 
 
 async def _async_service_battery_discharge(call: ServiceCall) -> None:
     """Handle the setbatterydischarge service."""
-    client = _resolve_client_for_serial(call.hass, call.data["serial"])
-    await client.updateDisChargeConfigInfo(
-        call.data["serial"], call.data["dischargecutoffsoc"],
-        int(call.data["enabled"] is True), call.data["dp1end"],
-        call.data["dp2end"], call.data["dp1start"],
-        call.data["dp2start"],
+    serial = call.data["serial"]
+    coordinator = _resolve_coordinator_for_serial(call.hass, serial)
+    await coordinator.async_write_discharge_config(
+        serial,
+        bat_use_cap=call.data["dischargecutoffsoc"],
+        ctr_dis=int(call.data["enabled"] is True),
+        times={
+            "timeDisf1": call.data["dp1start"], "timeDise1": call.data["dp1end"],
+            "timeDisf2": call.data["dp2start"], "timeDise2": call.data["dp2end"],
+        },
     )
 
 
@@ -366,6 +376,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: AlphaESSConfigEntry) -> 
     await _coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = _coordinator
+
+    # Determine once per inverter whether the periodic schedule API is usable.
+    # Systems that aren't entitled return 6017 and keep using only the legacy
+    # endpoints. Never fatal — a failure here just leaves it to be retried on
+    # the first write.
+    for serial in list(_coordinator.data):
+        await _coordinator.async_probe_periodic_support(serial)
 
     # Auto-create EV charger subentries for any discovered chargers
     existing_ev_serials = {

--- a/custom_components/alphaess/__init__.py
+++ b/custom_components/alphaess/__init__.py
@@ -234,30 +234,38 @@ async def _async_service_battery_charge(call: ServiceCall) -> None:
     """Handle the setbatterycharge service."""
     serial = call.data["serial"]
     coordinator = _resolve_coordinator_for_serial(call.hass, serial)
-    await coordinator.async_write_charge_config(
-        serial,
-        bat_high_cap=call.data["chargestopsoc"],
-        grid_charge=int(call.data["enabled"] is True),
-        times={
-            "timeChaf1": call.data["cp1start"], "timeChae1": call.data["cp1end"],
-            "timeChaf2": call.data["cp2start"], "timeChae2": call.data["cp2end"],
-        },
-    )
+    try:
+        await coordinator.async_write_charge_config(
+            serial,
+            bat_high_cap=call.data["chargestopsoc"],
+            grid_charge=int(call.data["enabled"] is True),
+            times={
+                "timeChaf1": call.data["cp1start"], "timeChae1": call.data["cp1end"],
+                "timeChaf2": call.data["cp2start"], "timeChae2": call.data["cp2end"],
+            },
+        )
+    except AlphaESSApiError as err:
+        raise HomeAssistantError(
+            f"AlphaESS rejected the charge settings for {serial}: {err}") from err
 
 
 async def _async_service_battery_discharge(call: ServiceCall) -> None:
     """Handle the setbatterydischarge service."""
     serial = call.data["serial"]
     coordinator = _resolve_coordinator_for_serial(call.hass, serial)
-    await coordinator.async_write_discharge_config(
-        serial,
-        bat_use_cap=call.data["dischargecutoffsoc"],
-        ctr_dis=int(call.data["enabled"] is True),
-        times={
-            "timeDisf1": call.data["dp1start"], "timeDise1": call.data["dp1end"],
-            "timeDisf2": call.data["dp2start"], "timeDise2": call.data["dp2end"],
-        },
-    )
+    try:
+        await coordinator.async_write_discharge_config(
+            serial,
+            bat_use_cap=call.data["dischargecutoffsoc"],
+            ctr_dis=int(call.data["enabled"] is True),
+            times={
+                "timeDisf1": call.data["dp1start"], "timeDise1": call.data["dp1end"],
+                "timeDisf2": call.data["dp2start"], "timeDise2": call.data["dp2end"],
+            },
+        )
+    except AlphaESSApiError as err:
+        raise HomeAssistantError(
+            f"AlphaESS rejected the discharge settings for {serial}: {err}") from err
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AlphaESSConfigEntry) -> bool:

--- a/custom_components/alphaess/__init__.py
+++ b/custom_components/alphaess/__init__.py
@@ -21,8 +21,10 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import slugify
 
 from alphaess import alphaess
+from alphaess.alphaess import AlphaESSApiError
 
 from .const import (
+    AUTH_FAILURE_CODES,
     CONF_ALT_POLLING_MODE,
     CONF_DISABLE_NOTIFICATIONS,
     CONF_EV_CHARGER_MODEL,
@@ -271,17 +273,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: AlphaESSConfigEntry) -> 
 
     # Don't set a single IP on the client - the coordinator handles per-inverter IPs.
     # Use HA's shared aiohttp session; the library applies verify_ssl per request.
+    # raise_on_error surfaces the API's own return code instead of collapsing
+    # every failure to None. That is the only way to tell an accepted schedule
+    # write from a rejected one, since those endpoints answer with data: null
+    # either way. Reads stay tolerant of it — see AlphaESSDataUpdateCoordinator._read.
     client = alphaess.alphaess(
         entry.data["AppID"],
         entry.data["AppSecret"],
         session=async_get_clientsession(hass),
-        verify_ssl=verify_ssl
+        verify_ssl=verify_ssl,
+        raise_on_error=True,
     )
 
     # Call getESSList to initialise the API client and discover systems
     # This is required before getdata() will work
     try:
         ess_list = await client.getESSList()
+    except AlphaESSApiError as err:
+        # The API answered and refused. Bad credentials show up here as a
+        # return code rather than an HTTP 401.
+        if err.code in AUTH_FAILURE_CODES:
+            raise ConfigEntryAuthFailed(
+                f"AlphaESS credentials rejected: {err}") from err
+        raise ConfigEntryNotReady(f"AlphaESS cloud API refused the request: {err}") from err
     except aiohttp.ClientResponseError as err:
         if err.status == 401:
             raise ConfigEntryAuthFailed("AlphaESS credentials rejected") from err

--- a/custom_components/alphaess/__init__.py
+++ b/custom_components/alphaess/__init__.py
@@ -382,7 +382,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: AlphaESSConfigEntry) -> 
     # endpoints. Never fatal — a failure here just leaves it to be retried on
     # the first write.
     for serial in list(_coordinator.data):
-        await _coordinator.async_probe_periodic_support(serial)
+        await _coordinator.async_probe_periodic_readable(serial)
 
     # Auto-create EV charger subentries for any discovered chargers
     existing_ev_serials = {

--- a/custom_components/alphaess/button.py
+++ b/custom_components/alphaess/button.py
@@ -4,6 +4,8 @@ import time as time_mod
 from homeassistant.components.button import ButtonEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from alphaess.alphaess import AlphaESSApiError
+
 from .const import (
     ALPHA_POST_REQUEST_RESTRICTION,
     CONF_DISABLE_NOTIFICATIONS,
@@ -227,7 +229,21 @@ class AlphaESSBatteryButton(CoordinatorEntity, ButtonEntity):
             last_update = last_update_dict.get(self._serial)
             if last_update is None or now - last_update >= rate_limit:
                 last_update_dict[self._serial] = now
-                await update_fn(update_key, self._serial, self._time)
+                try:
+                    await update_fn(update_key, self._serial, self._time)
+                except AlphaESSApiError as err:
+                    # Nothing was applied, so don't make the user sit out the
+                    # rate limit before they can try again.
+                    last_update_dict[self._serial] = last_update
+                    _LOGGER.error("%s command rejected for %s: %s",
+                                  movement_direction, self._serial, err)
+                    if not self._notifications_disabled:
+                        await create_persistent_notification(
+                            self.hass,
+                            message=f"AlphaESS rejected the {movement_direction.lower()} command "
+                                    f"for {self._serial}: {err}",
+                            title=f"{self._serial} {movement_direction} failed")
+                    return
                 _LOGGER.info("Notifications disabled = %s for %s", self._notifications_disabled, self._serial)
                 if not self._notifications_disabled:
                     _LOGGER.info("Sending notification for %s %s", self._serial, movement_direction)
@@ -250,8 +266,21 @@ class AlphaESSBatteryButton(CoordinatorEntity, ButtonEntity):
                 self._serial] >= rate_limit) and \
                     (last_discharge_update.get(self._serial) is None or now - last_discharge_update[
                         self._serial] >= rate_limit):
+                previous_charge = last_charge_update.get(self._serial)
+                previous_discharge = last_discharge_update.get(self._serial)
                 last_discharge_update[self._serial] = last_charge_update[self._serial] = now
-                await self._coordinator.reset_config(self._serial)
+                try:
+                    await self._coordinator.reset_config(self._serial)
+                except AlphaESSApiError as err:
+                    last_charge_update[self._serial] = previous_charge
+                    last_discharge_update[self._serial] = previous_discharge
+                    _LOGGER.error("Reset rejected for %s: %s", self._serial, err)
+                    if not self._notifications_disabled:
+                        await create_persistent_notification(
+                            self.hass,
+                            message=f"AlphaESS rejected the reset for {self._serial}: {err}",
+                            title=f"{self._serial} Reset failed")
+                    return
                 if not self._notifications_disabled:
                     await create_persistent_notification(self.hass,
                                                          message=f"Charge and discharge configuration reset for {self._serial}.",

--- a/custom_components/alphaess/config_flow.py
+++ b/custom_components/alphaess/config_flow.py
@@ -22,8 +22,10 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from alphaess import alphaess
+from alphaess.alphaess import AlphaESSApiError
 
 from .const import (
+    AUTH_FAILURE_CODES,
     CONF_ALT_POLLING_MODE,
     CONF_DISABLE_NOTIFICATIONS,
     CONF_FAST_SCAN_INTERVAL_SECONDS,
@@ -63,10 +65,14 @@ STEP_USER_DATA_SCHEMA = vol.Schema({
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input and return discovered systems."""
 
+    # raise_on_error so a rejected sign check is reported as such. Without it
+    # the API answers 6007 with an empty body, the call returns None, and an
+    # entry gets created around credentials that will never work.
     client = alphaess.alphaess(
         data["AppID"], data["AppSecret"],
         session=async_get_clientsession(hass),
-        verify_ssl=data.get("Verify SSL Certificate", True)
+        verify_ssl=data.get("Verify SSL Certificate", True),
+        raise_on_error=True,
     )
 
     try:
@@ -75,6 +81,10 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         ess_list = await client.getESSList()
         await asyncio.sleep(1)
 
+    except AlphaESSApiError as e:
+        if e.code in AUTH_FAILURE_CODES:
+            raise InvalidAuth from e
+        raise CannotConnect from e
     except aiohttp.ClientResponseError as e:
         if e.status == 401:
             raise InvalidAuth

--- a/custom_components/alphaess/const.py
+++ b/custom_components/alphaess/const.py
@@ -6,10 +6,14 @@ from homeassistant.const import Platform
 
 DOMAIN = "alphaess"
 
-# Return codes that mean the credentials or the binding are wrong, rather than
-# something transient. 6007 sign verification, 6009 whitelist, 6010 sign empty,
-# 6012 appId empty, 6005 appId not bound to the SN.
-AUTH_FAILURE_CODES = {6005, 6007, 6009, 6010, 6012}
+# Return codes that mean the AppID/AppSecret pair itself is wrong, so asking the
+# user to re-enter them can actually fix it: 6007 sign verification failed,
+# 6010 sign is empty, 6012 appId is empty.
+#
+# Deliberately excludes codes that reauth cannot fix -- 6005 (appId not bound to
+# that SN) and 6009 (IP whitelist) are configuration problems on the portal
+# side, and prompting for credentials would send the user round in circles.
+AUTH_FAILURE_CODES = {6007, 6010, 6012}
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,

--- a/custom_components/alphaess/const.py
+++ b/custom_components/alphaess/const.py
@@ -5,6 +5,11 @@ from datetime import timedelta
 from homeassistant.const import Platform
 
 DOMAIN = "alphaess"
+
+# Return codes that mean the credentials or the binding are wrong, rather than
+# something transient. 6007 sign verification, 6009 whitelist, 6010 sign empty,
+# 6012 appId empty, 6005 appId not bound to the SN.
+AUTH_FAILURE_CODES = {6005, 6007, 6009, 6010, 6012}
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -539,6 +539,14 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         """Read a per-inverter number setting."""
         return self.number_settings.get(serial, {}).get(key, default)
 
+    def clear_number_setting(self, serial: str, key: str) -> None:
+        """Forget a stored setting so callers fall back to their default.
+
+        Storing None instead would shadow that default, since get_number_setting
+        only substitutes when the key is absent.
+        """
+        self.number_settings.get(serial, {}).pop(key, None)
+
     def get_ev_charger_subentry_id(self, ev_serial: str) -> str | None:
         """Get the subentry ID for an EV charger by its serial number."""
         return self._ev_charger_subentry_map.get(ev_serial)

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -27,6 +27,56 @@ from .enums import AlphaESSNames
 
 _LOGGER = logging.getLogger(__name__)
 
+# --- Periodic (setTimeChargeBySn) schedule -----------------------------------
+# executeCycleType 0 = daily, 1 = weekly. We always write daily so the periodic
+# schedule mirrors the two-slot legacy config the entities are modelled on;
+# per-weekday scheduling is intentionally out of scope (see issue #267).
+PERIODIC_DAILY = 0
+
+# chargeLimit is documented as [10, 100]; anything outside returns 6001.
+PERIODIC_MIN_CHARGE_LIMIT = 10
+PERIODIC_MAX_CHARGE_LIMIT = 100
+
+MINUTES_PER_DAY = 1440
+
+
+def _time_to_minutes(value: str) -> int:
+    """Convert an "HH:mm" string into minutes since midnight."""
+    hours, _, minutes = value.partition(":")
+    return int(hours) * 60 + int(minutes)
+
+
+def _period_intervals(period: dict[str, Any]) -> list[tuple[int, int]]:
+    """Return the half-open minute intervals a period covers.
+
+    A period whose end is not after its start wraps midnight, so it is split
+    into two intervals to keep overlap testing simple.
+    """
+    start = _time_to_minutes(period["beginTime"])
+    end = _time_to_minutes(period["endTime"])
+    if end > start:
+        return [(start, end)]
+    return [(start, MINUTES_PER_DAY), (0, end)]
+
+
+def find_overlapping_periods(
+    charge_periods: list[dict[str, Any]],
+    discharge_periods: list[dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Return the first charge/discharge period pair that overlaps, if any.
+
+    The legacy endpoints happily accept overlapping charge and discharge
+    windows, but setTimeChargeBySn rejects them with 6008. Callers use this to
+    skip the periodic write instead of failing it.
+    """
+    for charge in charge_periods:
+        for discharge in discharge_periods:
+            for c_start, c_end in _period_intervals(charge):
+                for d_start, d_end in _period_intervals(discharge):
+                    if c_start < d_end and d_start < c_end:
+                        return charge, discharge
+    return None
+
 
 class DataProcessor:
     """Helper class for data processing utilities."""
@@ -402,6 +452,14 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         # keyed by serial then setting key. Replaces the old hass.data[DOMAIN][serial] store.
         self.number_settings: dict[str, dict[str, float]] = {}
 
+        # Periodic schedule (setTimeChargeBySn) entitlement per serial.
+        # Missing/None = not yet determined, True/False = known answer.
+        self._periodic_support: dict[str, bool] = {}
+
+        # Last known chargePower per serial, keyed "charge"/"discharge", so a
+        # power setpoint configured in the AlphaESS app survives our writes.
+        self._periodic_power: dict[str, dict[str, int]] = {}
+
         # Guards temporary mutation of the shared API client's ipaddress
         self._local_ip_lock = asyncio.Lock()
 
@@ -492,41 +550,46 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         bat_use_cap = self.get_number_setting(serial, "batUseCap", 10)
         bat_high_cap = self.get_number_setting(serial, "batHighCap", 90)
 
-        results = await self._reset_charge_discharge_config(serial, bat_high_cap, bat_use_cap)
-        _LOGGER.info(
-            "Reset Charge and Discharge configuration - Charge: %s, Discharge: %s",
-            results["charge"], results["discharge"],
+        await self._async_apply_schedule(
+            serial,
+            charge={
+                "batHighCap": bat_high_cap,
+                "gridCharge": 1,
+                "timeChaf1": "00:00", "timeChae1": "00:00",
+                "timeChaf2": "00:00", "timeChae2": "00:00",
+            },
+            discharge={
+                "batUseCap": bat_use_cap,
+                "ctrDis": 1,
+                "timeDisf1": "00:00", "timeDise1": "00:00",
+                "timeDisf2": "00:00", "timeDise2": "00:00",
+            },
         )
+        _LOGGER.info("Reset charge and discharge configuration for %s", serial)
         # Optimistically update so switches reflect the change immediately
         if serial in self.data:
             self.data[serial]["gridCharge"] = 1
             self.data[serial]["ctrDis"] = 1
             self.async_set_updated_data(self.data)
 
-    async def _reset_charge_discharge_config(
-            self, serial: str, bat_high_cap: int, bat_use_cap: int
-    ) -> dict[str, Any]:
-        """Internal method to reset configurations."""
-        charge_result = await self.api.updateChargeConfigInfo(
-            serial, bat_high_cap, 1, "00:00", "00:00", "00:00", "00:00"
-        )
-        discharge_result = await self.api.updateDisChargeConfigInfo(
-            serial, bat_use_cap, 1, "00:00", "00:00", "00:00", "00:00"
-        )
-        return {"charge": charge_result, "discharge": discharge_result}
-
     async def update_discharge(self, name: str, serial: str, time_period: int) -> None:
         """Update discharge configuration for specified time period."""
         bat_use_cap = self.get_number_setting(serial, name, 10)
         start_time, end_time = self.time_helper.calculate_time_window(time_period)
 
-        result = await self.api.updateDisChargeConfigInfo(
-            serial, bat_use_cap, 1, end_time, "00:00", start_time, "00:00"
+        await self.async_write_discharge_config(
+            serial,
+            bat_use_cap=bat_use_cap,
+            ctr_dis=1,
+            times={
+                "timeDisf1": start_time, "timeDise1": end_time,
+                "timeDisf2": "00:00", "timeDise2": "00:00",
+            },
         )
 
         _LOGGER.info(
-            "Updated discharge config - Capacity: %s, Period: %s to %s, Result: %s",
-            bat_use_cap, start_time, end_time, result,
+            "Updated discharge config - Capacity: %s, Period: %s to %s",
+            bat_use_cap, start_time, end_time,
         )
         # Optimistically update so the discharge switch reflects enabled immediately
         if serial in self.data:
@@ -538,18 +601,311 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         bat_high_cap = self.get_number_setting(serial, name, 90)
         start_time, end_time = self.time_helper.calculate_time_window(time_period)
 
-        result = await self.api.updateChargeConfigInfo(
-            serial, bat_high_cap, 1, end_time, "00:00", start_time, "00:00"
+        await self.async_write_charge_config(
+            serial,
+            bat_high_cap=bat_high_cap,
+            grid_charge=1,
+            times={
+                "timeChaf1": start_time, "timeChae1": end_time,
+                "timeChaf2": "00:00", "timeChae2": "00:00",
+            },
         )
 
         _LOGGER.info(
-            "Updated charge config - Capacity: %s, Period: %s to %s, Result: %s",
-            bat_high_cap, start_time, end_time, result,
+            "Updated charge config - Capacity: %s, Period: %s to %s",
+            bat_high_cap, start_time, end_time,
         )
         # Optimistically update so the charge switch reflects enabled immediately
         if serial in self.data:
             self.data[serial]["gridCharge"] = 1
             self.async_set_updated_data(self.data)
+
+    # ------------------------------------------------------------------
+    # Charge / discharge schedule writes
+    #
+    # AlphaESS has migrated some regions (UK, AUS/NZ) to a backend that only
+    # acts on the periodic schedule API. There, updateChargeConfigInfo still
+    # answers 200 but the inverter never applies the change until someone
+    # presses Save in the app (issue #267), or the downstream SetConfig times
+    # out entirely (issue #269). Other regions only understand the legacy
+    # endpoints. So every write goes to both: periodic first, legacy after.
+    # ------------------------------------------------------------------
+
+    async def async_write_charge_config(
+        self,
+        serial: str,
+        *,
+        bat_high_cap: float | None = None,
+        grid_charge: int | None = None,
+        times: dict[str, str] | None = None,
+    ) -> None:
+        """Apply a charge configuration change.
+
+        `times` is keyed by the legacy API names (timeChaf1/timeChae1/
+        timeChaf2/timeChae2); anything omitted keeps its current value.
+        """
+        overrides: dict[str, Any] = dict(times or {})
+        if bat_high_cap is not None:
+            overrides["batHighCap"] = bat_high_cap
+        if grid_charge is not None:
+            overrides["gridCharge"] = grid_charge
+        await self._async_apply_schedule(serial, charge=overrides)
+
+    async def async_write_discharge_config(
+        self,
+        serial: str,
+        *,
+        bat_use_cap: float | None = None,
+        ctr_dis: int | None = None,
+        times: dict[str, str] | None = None,
+    ) -> None:
+        """Apply a discharge configuration change.
+
+        `times` is keyed by the legacy API names (timeDisf1/timeDise1/
+        timeDisf2/timeDise2); anything omitted keeps its current value.
+        """
+        overrides: dict[str, Any] = dict(times or {})
+        if bat_use_cap is not None:
+            overrides["batUseCap"] = bat_use_cap
+        if ctr_dis is not None:
+            overrides["ctrDis"] = ctr_dis
+        await self._async_apply_schedule(serial, discharge=overrides)
+
+    def _current_schedule_state(self, serial: str) -> dict[str, dict[str, Any]]:
+        """Read the full charge and discharge config out of coordinator data."""
+        data = self.data.get(serial) or {}
+
+        def value_or(key: Any, default: Any) -> Any:
+            # The parsers store None when the API omitted a field, so a plain
+            # dict.get(key, default) would hand None straight to the API. Note
+            # 0 is a valid value for gridCharge/ctrDis, so `or` won't do.
+            value = data.get(key)
+            return default if value is None else value
+
+        return {
+            "charge": {
+                "batHighCap": value_or(AlphaESSNames.batHighCap, 90),
+                "gridCharge": value_or("gridCharge", 1),
+                "timeChaf1": data.get("charge_timeChaf1") or "00:00",
+                "timeChae1": data.get("charge_timeChae1") or "00:00",
+                "timeChaf2": data.get("charge_timeChaf2") or "00:00",
+                "timeChae2": data.get("charge_timeChae2") or "00:00",
+            },
+            "discharge": {
+                "batUseCap": value_or(AlphaESSNames.batUseCap, 10),
+                "ctrDis": value_or("ctrDis", 1),
+                "timeDisf1": data.get("discharge_timeDisf1") or "00:00",
+                "timeDise1": data.get("discharge_timeDise1") or "00:00",
+                "timeDisf2": data.get("discharge_timeDisf2") or "00:00",
+                "timeDise2": data.get("discharge_timeDise2") or "00:00",
+            },
+        }
+
+    async def _async_apply_schedule(
+        self,
+        serial: str,
+        *,
+        charge: dict[str, Any] | None = None,
+        discharge: dict[str, Any] | None = None,
+    ) -> None:
+        """Write a charge and/or discharge change to both scheduling APIs.
+
+        The periodic write goes first and its errors propagate, so an entity
+        that optimistically updated itself can revert. The legacy write always
+        follows; once the periodic write has been accepted a legacy failure is
+        only logged, because the inverter already has the schedule it acts on.
+        """
+        state = self._current_schedule_state(serial)
+        if charge:
+            state["charge"].update(charge)
+        if discharge:
+            state["discharge"].update(discharge)
+
+        periodic_written = await self._async_write_periodic_schedule(serial, state)
+
+        try:
+            if charge is not None:
+                await self._async_write_legacy_charge(serial, state["charge"])
+            if discharge is not None:
+                await self._async_write_legacy_discharge(serial, state["discharge"])
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            if not periodic_written:
+                raise
+            _LOGGER.warning(
+                "Legacy charge/discharge write failed for %s (%s), but the periodic "
+                "schedule was accepted so the change should still take effect",
+                serial, err,
+            )
+
+    async def async_probe_periodic_support(self, serial: str) -> bool | None:
+        """Determine whether a system can use the periodic schedule API.
+
+        Returns True/False once known and caches it. Returns None when the
+        answer could not be established (transport error), leaving the cache
+        untouched so the next write retries.
+        """
+        try:
+            payload = await self.api.getTimeChargeBySn(serial)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug("Periodic schedule probe failed for %s: %s", serial, err)
+            return None
+
+        if not payload:
+            # The library returns None for API-level rejections, which for this
+            # endpoint means 6017 "no operation permissions" — the system isn't
+            # entitled to the feature. Not a transient error, so cache it.
+            _LOGGER.debug(
+                "Periodic schedule API unavailable for %s, using the legacy endpoints",
+                serial,
+            )
+            self._periodic_support[serial] = False
+            return False
+
+        self._periodic_support[serial] = True
+        self._cache_periodic_power(serial, payload)
+        _LOGGER.debug("Periodic schedule API available for %s", serial)
+        return True
+
+    def _cache_periodic_power(self, serial: str, payload: dict[str, Any]) -> None:
+        """Remember the chargePower setpoints already configured on a system."""
+        powers: dict[str, int] = {}
+        for name, key in (("charge", "chargeTimeList"), ("discharge", "dischargeTimeList")):
+            for period in payload.get(key) or []:
+                power = period.get("chargePower")
+                if power is not None:
+                    powers[name] = power
+                    break
+        if powers:
+            self._periodic_power.setdefault(serial, {}).update(powers)
+
+    @staticmethod
+    def _build_period_list(
+        slots: list[tuple[str | None, str | None]],
+        charge_limit: Any,
+        charge_power: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Build a setTimeChargeBySn period list from legacy two-slot times.
+
+        Slots whose start equals their end are the legacy way of saying
+        "disabled"; the periodic API has no zero-length period, so they are
+        dropped and an all-disabled config becomes an empty list.
+        """
+        try:
+            limit: float = float(charge_limit)
+        except (TypeError, ValueError):
+            limit = PERIODIC_MIN_CHARGE_LIMIT
+        clamped = max(PERIODIC_MIN_CHARGE_LIMIT, min(PERIODIC_MAX_CHARGE_LIMIT, limit))
+        if clamped != limit:
+            _LOGGER.debug(
+                "Clamped periodic chargeLimit from %s to %s (allowed range is %s-%s)",
+                charge_limit, clamped, PERIODIC_MIN_CHARGE_LIMIT, PERIODIC_MAX_CHARGE_LIMIT,
+            )
+
+        periods: list[dict[str, Any]] = []
+        for begin, end in slots:
+            if not begin or not end or begin == end:
+                continue
+            period: dict[str, Any] = {
+                "beginTime": begin,
+                "endTime": end,
+                "chargeLimit": clamped,
+            }
+            if charge_power is not None:
+                period["chargePower"] = charge_power
+            periods.append(period)
+        return periods
+
+    async def _async_write_periodic_schedule(
+        self, serial: str, state: dict[str, dict[str, Any]]
+    ) -> bool:
+        """Push the whole schedule via setTimeChargeBySn.
+
+        Returns True when the periodic API accepted the schedule, False when it
+        was skipped (system not entitled, or the config would be rejected).
+        Errors from the call itself propagate to the caller.
+        """
+        supported = self._periodic_support.get(serial)
+        if supported is None:
+            supported = await self.async_probe_periodic_support(serial)
+        if not supported:
+            return False
+
+        charge = state["charge"]
+        discharge = state["discharge"]
+        powers = self._periodic_power.get(serial, {})
+
+        charge_periods = self._build_period_list(
+            [
+                (charge["timeChaf1"], charge["timeChae1"]),
+                (charge["timeChaf2"], charge["timeChae2"]),
+            ],
+            charge["batHighCap"],
+            powers.get("charge"),
+        )
+        discharge_periods = self._build_period_list(
+            [
+                (discharge["timeDisf1"], discharge["timeDise1"]),
+                (discharge["timeDisf2"], discharge["timeDise2"]),
+            ],
+            discharge["batUseCap"],
+            powers.get("discharge"),
+        )
+
+        overlap = find_overlapping_periods(charge_periods, discharge_periods)
+        if overlap:
+            _LOGGER.warning(
+                "Skipping the periodic schedule write for %s: charge period %s-%s "
+                "overlaps discharge period %s-%s, which setTimeChargeBySn rejects. "
+                "Adjust the periods so they do not overlap",
+                serial,
+                overlap[0]["beginTime"], overlap[0]["endTime"],
+                overlap[1]["beginTime"], overlap[1]["endTime"],
+            )
+            return False
+
+        result = await self.api.setTimeChargeBySn(
+            serial,
+            PERIODIC_DAILY,
+            charge_periods,
+            discharge_periods,
+            gridChargeCycle=int(charge["gridCharge"]),
+            ctrDisCycle=int(discharge["ctrDis"]),
+        )
+        _LOGGER.info(
+            "Wrote periodic schedule for %s - charge: %s, discharge: %s, Result: %s",
+            serial, charge_periods, discharge_periods, result,
+        )
+        return True
+
+    async def _async_write_legacy_charge(self, serial: str, charge: dict[str, Any]) -> None:
+        """Write the two-slot charge config via updateChargeConfigInfo."""
+        result = await self.api.updateChargeConfigInfo(
+            serial,
+            charge["batHighCap"],
+            charge["gridCharge"],
+            charge["timeChae1"],
+            charge["timeChae2"],
+            charge["timeChaf1"],
+            charge["timeChaf2"],
+        )
+        _LOGGER.info("Updated charge config for %s: %s - Result: %s", serial, charge, result)
+
+    async def _async_write_legacy_discharge(self, serial: str, discharge: dict[str, Any]) -> None:
+        """Write the two-slot discharge config via updateDisChargeConfigInfo."""
+        result = await self.api.updateDisChargeConfigInfo(
+            serial,
+            discharge["batUseCap"],
+            discharge["ctrDis"],
+            discharge["timeDise1"],
+            discharge["timeDise2"],
+            discharge["timeDisf1"],
+            discharge["timeDisf2"],
+        )
+        _LOGGER.info("Updated discharge config for %s: %s - Result: %s", serial, discharge, result)
 
     async def _async_update_data(self) -> dict[str, dict[str, Any]] | None:
         """Update data via library."""

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -882,6 +882,22 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             powers.get("discharge"),
         )
 
+        # Both lists are required and neither may be empty: the live API answers
+        # an empty list with 6001 "time list is null", and omitting one with
+        # 10001. There is no verified way to express "no periods on this side" —
+        # a 00:00-00:00 element passes validation but its meaning is unconfirmed,
+        # and if the server reads end <= start as wrapping midnight it would be a
+        # 24-hour window. Skip rather than risk it; the legacy write still runs.
+        if not charge_periods or not discharge_periods:
+            _LOGGER.warning(
+                "Skipping the periodic schedule write for %s: setTimeChargeBySn "
+                "requires at least one charge period and one discharge period, "
+                "and %s is empty. Only the legacy endpoints were written",
+                serial,
+                "the charge list" if not charge_periods else "the discharge list",
+            )
+            return False
+
         overlap = find_overlapping_periods(charge_periods, discharge_periods)
         if overlap:
             _LOGGER.warning(

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from homeassistant.util import dt as dt_util
 
 from alphaess import alphaess
+from alphaess.alphaess import AlphaESSApiError
 
 from .const import (
     CONF_SERIAL_NUMBER,
@@ -44,6 +45,11 @@ PERIODIC_MAX_CHARGE_LIMIT = 100
 PERIODIC_READ_OK = "readable"
 PERIODIC_READ_UNAVAILABLE = "unreadable"
 PERIODIC_READ_UNKNOWN = "unknown"
+
+# "No operation permissions" — this system is not entitled to the periodic
+# endpoints. Documented as permanent, so it is worth caching rather than
+# retrying. See docs/RETURN_CODES.md in alphaess-openAPI.
+PERIODIC_NOT_ENTITLED = 6017
 
 MINUTES_PER_DAY = 1440
 
@@ -468,6 +474,11 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         # power setpoint configured in the AlphaESS app survives our writes.
         self._periodic_power: dict[str, dict[str, int]] = {}
 
+        # Serials whose periodic *write* came back 6017. Unlike the read, this
+        # is the endpoint we actually care about answering for itself, so once
+        # it refuses there is no point asking again.
+        self._periodic_write_denied: set[str] = set()
+
         # Guards temporary mutation of the shared API client's ipaddress
         self._local_ip_lock = asyncio.Lock()
 
@@ -481,6 +492,26 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                     self._inverter_subentry_map[serial] = subentry_id
                 elif subentry.subentry_type == SUBENTRY_TYPE_EV_CHARGER:
                     self._ev_charger_subentry_map[serial] = subentry_id
+
+    async def _read(self, method, *args) -> Any:
+        """Run a polling read, tolerating an API-level rejection.
+
+        The client runs with raise_on_error so writes can tell success from
+        failure. Reads want the older, softer behaviour: an endpoint this
+        account cannot use (6017) or a momentarily unhappy one should leave that
+        one value missing, not abort the whole inverter fetch and trip the
+        error backoff. Transport errors still propagate — those really do mean
+        the inverter is unreachable.
+        """
+        try:
+            return await method(*args)
+        except AlphaESSApiError as err:
+            _LOGGER.debug(
+                "%s returned %s%s; continuing without it",
+                getattr(method, "__name__", method), err.code,
+                f" ({err.description})" if err.description else "",
+            )
+            return None
 
     def get_inverter_subentry_id(self, serial: str) -> str | None:
         """Get the subentry ID for an inverter by its serial number."""
@@ -779,18 +810,24 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             payload = await self.api.getTimeChargeBySn(serial)
         except asyncio.CancelledError:
             raise
+        except AlphaESSApiError as err:
+            # The API answered and refused. 6017 means this system is not
+            # entitled to the feature, which will not change on a retry, so
+            # cache it. Anything else might, so leave the answer open.
+            if err.code == PERIODIC_NOT_ENTITLED:
+                _LOGGER.debug(
+                    "Periodic schedule not readable for %s (%s)", serial, err.code)
+                self._periodic_readable[serial] = False
+                return False
+            _LOGGER.debug("Periodic schedule read for %s failed with %s", serial, err.code)
+            return None
         except Exception as err:
             _LOGGER.debug("Periodic schedule probe failed for %s: %s", serial, err)
             return None
 
         if not payload:
-            # The library returns None for API-level rejections, which for this
-            # endpoint means 6017 "no operation permissions" — the system isn't
-            # entitled to the feature. Not a transient error, so cache it.
-            _LOGGER.debug(
-                "Periodic schedule API unavailable for %s, using the legacy endpoints",
-                serial,
-            )
+            # Answered successfully but with nothing in it.
+            _LOGGER.debug("Periodic schedule for %s read back empty", serial)
             self._periodic_readable[serial] = False
             return False
 
@@ -854,13 +891,16 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         """Push the whole schedule via setTimeChargeBySn.
 
         Always attempted — see _async_apply_schedule for why this is not gated
-        on the read endpoint.
+        on the read endpoint — except on systems the API has already told us
+        outright are not entitled to it.
 
-        Returns True when the request completed without raising. That is not
-        proof the schedule was accepted: the API answers with null data whether
-        it succeeded or not, so the library cannot tell the two apart. A
-        rejection still shows up as an error in the log from the library.
+        Returns True only when the API accepted the schedule. The client runs
+        with raise_on_error, so a rejection arrives as AlphaESSApiError rather
+        than being flattened into the same None a success returns.
         """
+        if serial in self._periodic_write_denied:
+            return False
+
         charge = state["charge"]
         discharge = state["discharge"]
         powers = self._periodic_power.get(serial, {})
@@ -921,6 +961,22 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             )
         except asyncio.CancelledError:
             raise
+        except AlphaESSApiError as err:
+            if err.code == PERIODIC_NOT_ENTITLED:
+                # Definitive, and from the write itself rather than inferred
+                # from the read. Stop attempting it for this system.
+                self._periodic_write_denied.add(serial)
+                _LOGGER.info(
+                    "%s is not entitled to the periodic schedule API (%s); "
+                    "using the legacy endpoints only from now on",
+                    serial, err.code,
+                )
+            else:
+                _LOGGER.warning(
+                    "Periodic schedule write for %s rejected with %s%s",
+                    serial, err.code, f" - {err.expMsg}" if err.expMsg else "",
+                )
+            return False
         except Exception as err:
             # Don't give up on the change — the legacy write still follows and
             # is what the unmigrated backends act on.
@@ -974,7 +1030,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             throttle_delay = self.throttle_multiplier
 
             # Get list of registered inverters
-            units = await self.api.getESSList()
+            units = await self._read(self.api.getESSList)
             if not units:
                 return self.data
 
@@ -1055,7 +1111,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 # Full poll — per-inverter API calls
                 self._last_poll_type = "full"
                 _LOGGER.debug("Alt mode: performing full poll")
-                units = await self.api.getESSList()
+                units = await self._read(self.api.getESSList)
                 if not units:
                     return self.data
 
@@ -1116,14 +1172,15 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                         # getLastPowerData — real-time watts/SOC (skip for unsupported models)
                         model = self.data[serial].get("Model")
                         if model not in LOWER_INVERTER_API_CALL_LIST:
-                            power_data = await self.api.getLastPowerData(serial)
+                            power_data = await self._read(self.api.getLastPowerData, serial)
                             if power_data:
                                 parsed = self.parser.parse_power_data(power_data, None)
                                 self.data[serial].update(parsed)
                             await asyncio.sleep(throttle_delay)
 
                         # getOneDateEnergyBySn — daily energy counters
-                        energy_data = await self.api.getOneDateEnergyBySn(
+                        energy_data = await self._read(
+                            self.api.getOneDateEnergyBySn,
                             serial, dt_util.now().strftime("%Y-%m-%d")
                         )
                         if energy_data:
@@ -1134,7 +1191,8 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                         # EV charger status if one is known
                         ev_sn = self.data[serial].get(AlphaESSNames.evchargersn)
                         if ev_sn:
-                            ev_status = await self.api.getEvChargerStatusBySn(serial, ev_sn)
+                            ev_status = await self._read(
+                                self.api.getEvChargerStatusBySn, serial, ev_sn)
                             if ev_status:
                                 self.data[serial][AlphaESSNames.evchargerstatus] = ev_status.get("evchargerStatus")
                                 self.data[serial][AlphaESSNames.evchargerstatusraw] = ev_status.get("evchargerStatus")
@@ -1217,39 +1275,41 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         """Fetch all API data for a single inverter by its serial number."""
         today = dt_util.now().strftime("%Y-%m-%d")
 
-        unit["SumData"] = await self.api.getSumDataForCustomer(serial)
+        unit["SumData"] = await self._read(self.api.getSumDataForCustomer, serial)
         await asyncio.sleep(throttle_delay)
 
-        unit["OneDateEnergy"] = await self.api.getOneDateEnergyBySn(serial, today)
+        unit["OneDateEnergy"] = await self._read(self.api.getOneDateEnergyBySn, serial, today)
         await asyncio.sleep(throttle_delay)
 
         # Skip getLastPowerData for inverters that don't support it
         if unit.get("minv") not in LOWER_INVERTER_API_CALL_LIST:
-            unit["LastPower"] = await self.api.getLastPowerData(serial)
+            unit["LastPower"] = await self._read(self.api.getLastPowerData, serial)
             await asyncio.sleep(throttle_delay)
 
-        unit["ChargeConfig"] = await self.api.getChargeConfigInfo(serial)
+        unit["ChargeConfig"] = await self._read(self.api.getChargeConfigInfo, serial)
         await asyncio.sleep(throttle_delay)
 
-        unit["DisChargeConfig"] = await self.api.getDisChargeConfigInfo(serial)
+        unit["DisChargeConfig"] = await self._read(self.api.getDisChargeConfigInfo, serial)
         await asyncio.sleep(throttle_delay)
 
         if get_power:
-            unit["OneDayPower"] = await self.api.getOneDayPowerBySn(serial, today)
+            unit["OneDayPower"] = await self._read(self.api.getOneDayPowerBySn, serial, today)
             await asyncio.sleep(throttle_delay)
 
         if get_ev:
             try:
-                unit["EVData"] = await self.api.getEvChargerConfigList(serial)
+                unit["EVData"] = await self._read(self.api.getEvChargerConfigList, serial)
                 await asyncio.sleep(throttle_delay)
                 if unit["EVData"]:
                     ev_list = unit["EVData"]
                     ev_item = ev_list[0] if isinstance(ev_list, list) else ev_list
                     ev_serial = ev_item.get("evchargerSn")
                     if ev_serial:
-                        unit["EVStatus"] = await self.api.getEvChargerStatusBySn(serial, ev_serial)
+                        unit["EVStatus"] = await self._read(
+                            self.api.getEvChargerStatusBySn, serial, ev_serial)
                         await asyncio.sleep(throttle_delay)
-                        unit["EVCurrent"] = await self.api.getEvChargerCurrentsBySn(serial)
+                        unit["EVCurrent"] = await self._read(
+                            self.api.getEvChargerCurrentsBySn, serial)
                         await asyncio.sleep(throttle_delay)
             except asyncio.CancelledError:
                 raise

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -37,6 +37,11 @@ PERIODIC_DAILY = 0
 PERIODIC_MIN_CHARGE_LIMIT = 10
 PERIODIC_MAX_CHARGE_LIMIT = 100
 
+# Values for the "Scheduling API" diagnostic sensor.
+SCHEDULING_API_PERIODIC = "periodic"
+SCHEDULING_API_LEGACY = "legacy"
+SCHEDULING_API_UNKNOWN = "unknown"
+
 MINUTES_PER_DAY = 1440
 
 
@@ -739,6 +744,18 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 serial, err,
             )
 
+    async def _async_resolve_unknown_scheduling_api(self) -> None:
+        """Retry the periodic probe for any inverter still undecided.
+
+        The setup probe can come back inconclusive if the cloud hiccups, which
+        would otherwise leave the Scheduling API sensor reading "unknown" until
+        someone happens to write a setting. Once an inverter has an answer it is
+        never probed again, so this costs at most one extra call per inverter.
+        """
+        for serial in list(self.data):
+            if serial not in self._periodic_support:
+                await self.async_probe_periodic_support(serial)
+
     async def async_probe_periodic_support(self, serial: str) -> bool | None:
         """Determine whether a system can use the periodic schedule API.
 
@@ -969,6 +986,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             self.cloud_available = any_success
             if any_success:
                 self._last_full_poll_utc = dt_util.utcnow().isoformat(timespec="seconds")
+                await self._async_resolve_unknown_scheduling_api()
             else:
                 _LOGGER.warning("All per-inverter fetches failed")
             return self._finalize_data()
@@ -1036,6 +1054,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 if any_success:
                     self._last_full_poll = now
                     self._last_full_poll_utc = dt_util.utcnow().isoformat(timespec="seconds")
+                    await self._async_resolve_unknown_scheduling_api()
                 else:
                     _LOGGER.warning("Alt mode: all per-inverter fetches failed during full poll")
             else:
@@ -1124,6 +1143,19 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             self.data[serial][AlphaESSNames.LastPollType] = self._last_poll_type
             self.data[serial][AlphaESSNames.LastFullPoll] = self._last_full_poll_utc or "never"
             self.data[serial][AlphaESSNames.PollTickCount] = self._poll_tick_count
+            self.data[serial][AlphaESSNames.SchedulingApi] = self.get_scheduling_api(serial)
+
+    def get_scheduling_api(self, serial: str) -> str:
+        """Return which scheduling API this system accepts.
+
+        "periodic" - the newer setTimeChargeBySn backend, written alongside the
+        legacy endpoints. "legacy" - only the old two-slot endpoints work here.
+        "unknown" - the probe hasn't produced an answer yet.
+        """
+        supported = self._periodic_support.get(serial)
+        if supported is None:
+            return SCHEDULING_API_UNKNOWN
+        return SCHEDULING_API_PERIODIC if supported else SCHEDULING_API_LEGACY
 
     def _finalize_data(self) -> dict[str, dict[str, Any]]:
         """Write diagnostics and return a shallow per-serial copy of the data.

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -37,10 +37,13 @@ PERIODIC_DAILY = 0
 PERIODIC_MIN_CHARGE_LIMIT = 10
 PERIODIC_MAX_CHARGE_LIMIT = 100
 
-# Values for the "Scheduling API" diagnostic sensor.
-SCHEDULING_API_PERIODIC = "periodic"
-SCHEDULING_API_LEGACY = "legacy"
-SCHEDULING_API_UNKNOWN = "unknown"
+# Values for the "Periodic Schedule Read" diagnostic sensor. This reports
+# whether getTimeChargeBySn can be read on this account, which is NOT the same
+# as whether the system is on the periodic backend — the read and write
+# endpoints are separately permissioned. Both APIs are written either way.
+PERIODIC_READ_OK = "readable"
+PERIODIC_READ_UNAVAILABLE = "unreadable"
+PERIODIC_READ_UNKNOWN = "unknown"
 
 MINUTES_PER_DAY = 1440
 
@@ -459,7 +462,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
 
         # Periodic schedule (setTimeChargeBySn) entitlement per serial.
         # Missing/None = not yet determined, True/False = known answer.
-        self._periodic_support: dict[str, bool] = {}
+        self._periodic_readable: dict[str, bool] = {}
 
         # Last known chargePower per serial, keyed "charge"/"discharge", so a
         # power setpoint configured in the AlphaESS app survives our writes.
@@ -715,10 +718,15 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
     ) -> None:
         """Write a charge and/or discharge change to both scheduling APIs.
 
-        The periodic write goes first and its errors propagate, so an entity
-        that optimistically updated itself can revert. The legacy write always
-        follows; once the periodic write has been accepted a legacy failure is
-        only logged, because the inverter already has the schedule it acts on.
+        Both are always written. Whether a system is on the periodic backend
+        cannot be detected up front — the read endpoint is separately
+        permissioned and returns 6017 on exactly the accounts that need the
+        periodic write most — so gating on it would skip the write for the
+        users this is meant to fix.
+
+        The change is only reported as failed when the legacy write fails and
+        the periodic one didn't go through either, so an entity that updated
+        itself optimistically reverts only when nothing was written at all.
         """
         state = self._current_schedule_state(serial)
         if charge:
@@ -740,28 +748,32 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 raise
             _LOGGER.warning(
                 "Legacy charge/discharge write failed for %s (%s), but the periodic "
-                "schedule was accepted so the change should still take effect",
+                "schedule request went through so the change may still take effect",
                 serial, err,
             )
 
-    async def _async_resolve_unknown_scheduling_api(self) -> None:
-        """Retry the periodic probe for any inverter still undecided.
+    async def _async_resolve_unknown_periodic_read(self) -> None:
+        """Retry the periodic read for any inverter still undecided.
 
-        The setup probe can come back inconclusive if the cloud hiccups, which
-        would otherwise leave the Scheduling API sensor reading "unknown" until
-        someone happens to write a setting. Once an inverter has an answer it is
-        never probed again, so this costs at most one extra call per inverter.
+        The setup read can come back inconclusive if the cloud hiccups, which
+        would otherwise leave the diagnostic sensor reading "unknown" forever.
+        Once an inverter has an answer it is never read again, so this costs at
+        most one extra call per inverter.
         """
         for serial in list(self.data):
-            if serial not in self._periodic_support:
-                await self.async_probe_periodic_support(serial)
+            if serial not in self._periodic_readable:
+                await self.async_probe_periodic_readable(serial)
 
-    async def async_probe_periodic_support(self, serial: str) -> bool | None:
-        """Determine whether a system can use the periodic schedule API.
+    async def async_probe_periodic_readable(self, serial: str) -> bool | None:
+        """Read the periodic schedule, to cache chargePower and for diagnostics.
+
+        This says whether the schedule is *readable* on this account, which is
+        not the same as whether the system is on the periodic backend — the two
+        are separately permissioned. It deliberately does not gate the write.
 
         Returns True/False once known and caches it. Returns None when the
         answer could not be established (transport error), leaving the cache
-        untouched so the next write retries.
+        untouched so it is retried later.
         """
         try:
             payload = await self.api.getTimeChargeBySn(serial)
@@ -779,10 +791,10 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 "Periodic schedule API unavailable for %s, using the legacy endpoints",
                 serial,
             )
-            self._periodic_support[serial] = False
+            self._periodic_readable[serial] = False
             return False
 
-        self._periodic_support[serial] = True
+        self._periodic_readable[serial] = True
         self._cache_periodic_power(serial, payload)
         _LOGGER.debug("Periodic schedule API available for %s", serial)
         return True
@@ -841,16 +853,14 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
     ) -> bool:
         """Push the whole schedule via setTimeChargeBySn.
 
-        Returns True when the periodic API accepted the schedule, False when it
-        was skipped (system not entitled, or the config would be rejected).
-        Errors from the call itself propagate to the caller.
-        """
-        supported = self._periodic_support.get(serial)
-        if supported is None:
-            supported = await self.async_probe_periodic_support(serial)
-        if not supported:
-            return False
+        Always attempted — see _async_apply_schedule for why this is not gated
+        on the read endpoint.
 
+        Returns True when the request completed without raising. That is not
+        proof the schedule was accepted: the API answers with null data whether
+        it succeeded or not, so the library cannot tell the two apart. A
+        rejection still shows up as an error in the log from the library.
+        """
         charge = state["charge"]
         discharge = state["discharge"]
         powers = self._periodic_power.get(serial, {})
@@ -884,17 +894,26 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             )
             return False
 
-        result = await self.api.setTimeChargeBySn(
-            serial,
-            PERIODIC_DAILY,
-            charge_periods,
-            discharge_periods,
-            gridChargeCycle=int(charge["gridCharge"]),
-            ctrDisCycle=int(discharge["ctrDis"]),
-        )
+        try:
+            await self.api.setTimeChargeBySn(
+                serial,
+                PERIODIC_DAILY,
+                charge_periods,
+                discharge_periods,
+                gridChargeCycle=int(charge["gridCharge"]),
+                ctrDisCycle=int(discharge["ctrDis"]),
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            # Don't give up on the change — the legacy write still follows and
+            # is what the unmigrated backends act on.
+            _LOGGER.warning("Periodic schedule write failed for %s: %s", serial, err)
+            return False
+
         _LOGGER.info(
-            "Wrote periodic schedule for %s - charge: %s, discharge: %s, Result: %s",
-            serial, charge_periods, discharge_periods, result,
+            "Wrote periodic schedule for %s - charge: %s, discharge: %s",
+            serial, charge_periods, discharge_periods,
         )
         return True
 
@@ -986,7 +1005,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             self.cloud_available = any_success
             if any_success:
                 self._last_full_poll_utc = dt_util.utcnow().isoformat(timespec="seconds")
-                await self._async_resolve_unknown_scheduling_api()
+                await self._async_resolve_unknown_periodic_read()
             else:
                 _LOGGER.warning("All per-inverter fetches failed")
             return self._finalize_data()
@@ -1054,7 +1073,7 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 if any_success:
                     self._last_full_poll = now
                     self._last_full_poll_utc = dt_util.utcnow().isoformat(timespec="seconds")
-                    await self._async_resolve_unknown_scheduling_api()
+                    await self._async_resolve_unknown_periodic_read()
                 else:
                     _LOGGER.warning("Alt mode: all per-inverter fetches failed during full poll")
             else:
@@ -1143,19 +1162,23 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             self.data[serial][AlphaESSNames.LastPollType] = self._last_poll_type
             self.data[serial][AlphaESSNames.LastFullPoll] = self._last_full_poll_utc or "never"
             self.data[serial][AlphaESSNames.PollTickCount] = self._poll_tick_count
-            self.data[serial][AlphaESSNames.SchedulingApi] = self.get_scheduling_api(serial)
+            self.data[serial][AlphaESSNames.PeriodicScheduleRead] = (
+                self.get_periodic_read_state(serial)
+            )
 
-    def get_scheduling_api(self, serial: str) -> str:
-        """Return which scheduling API this system accepts.
+    def get_periodic_read_state(self, serial: str) -> str:
+        """Return whether the periodic schedule can be read on this account.
 
-        "periodic" - the newer setTimeChargeBySn backend, written alongside the
-        legacy endpoints. "legacy" - only the old two-slot endpoints work here.
-        "unknown" - the probe hasn't produced an answer yet.
+        "readable" - getTimeChargeBySn returns a schedule. "unreadable" - it is
+        rejected, usually 6017. "unknown" - no answer yet.
+
+        This is a diagnostic only. An unreadable schedule does not mean the
+        system is on the old backend, and does not stop the periodic write.
         """
-        supported = self._periodic_support.get(serial)
-        if supported is None:
-            return SCHEDULING_API_UNKNOWN
-        return SCHEDULING_API_PERIODIC if supported else SCHEDULING_API_LEGACY
+        readable = self._periodic_readable.get(serial)
+        if readable is None:
+            return PERIODIC_READ_UNKNOWN
+        return PERIODIC_READ_OK if readable else PERIODIC_READ_UNAVAILABLE
 
     def _finalize_data(self) -> dict[str, dict[str, Any]]:
         """Write diagnostics and return a shallow per-serial copy of the data.

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -54,6 +54,21 @@ PERIODIC_NOT_ENTITLED = 6017
 MINUTES_PER_DAY = 1440
 
 
+def describe_api_error(err: AlphaESSApiError) -> str:
+    """Render a return code with the meaning the library has on file.
+
+    The English text comes from RETURN_CODES / UNDOCUMENTED_RETURN_CODES in
+    alphaess-openAPI, via the exception, so the wording stays in one place. A
+    code the library doesn't recognise still shows its number.
+    """
+    described = str(err.code)
+    if err.description:
+        described += f" ({err.description})"
+    if err.expMsg:
+        described += f" - {err.expMsg}"
+    return described
+
+
 def _time_to_minutes(value: str) -> int:
     """Convert an "HH:mm" string into minutes since midnight."""
     hours, _, minutes = value.partition(":")
@@ -507,9 +522,8 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             return await method(*args)
         except AlphaESSApiError as err:
             _LOGGER.debug(
-                "%s returned %s%s; continuing without it",
-                getattr(method, "__name__", method), err.code,
-                f" ({err.description})" if err.description else "",
+                "%s returned %s; continuing without it",
+                getattr(method, "__name__", method), describe_api_error(err),
             )
             return None
 
@@ -815,11 +829,12 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             # entitled to the feature, which will not change on a retry, so
             # cache it. Anything else might, so leave the answer open.
             if err.code == PERIODIC_NOT_ENTITLED:
-                _LOGGER.debug(
-                    "Periodic schedule not readable for %s (%s)", serial, err.code)
+                _LOGGER.debug("Periodic schedule not readable for %s: %s",
+                              serial, describe_api_error(err))
                 self._periodic_readable[serial] = False
                 return False
-            _LOGGER.debug("Periodic schedule read for %s failed with %s", serial, err.code)
+            _LOGGER.debug("Periodic schedule read for %s failed with %s",
+                          serial, describe_api_error(err))
             return None
         except Exception as err:
             _LOGGER.debug("Periodic schedule probe failed for %s: %s", serial, err)
@@ -967,14 +982,14 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 # from the read. Stop attempting it for this system.
                 self._periodic_write_denied.add(serial)
                 _LOGGER.info(
-                    "%s is not entitled to the periodic schedule API (%s); "
+                    "%s is not entitled to the periodic schedule API: %s; "
                     "using the legacy endpoints only from now on",
-                    serial, err.code,
+                    serial, describe_api_error(err),
                 )
             else:
                 _LOGGER.warning(
-                    "Periodic schedule write for %s rejected with %s%s",
-                    serial, err.code, f" - {err.expMsg}" if err.expMsg else "",
+                    "Periodic schedule write for %s rejected with %s",
+                    serial, describe_api_error(err),
                 )
             return False
         except Exception as err:

--- a/custom_components/alphaess/diagnostics.py
+++ b/custom_components/alphaess/diagnostics.py
@@ -40,8 +40,8 @@ async def async_get_config_entry_diagnostics(
     }
 
     # Keyed the same way so it lines up with the anonymised data above
-    scheduling_api = {
-        f"inverter_{idx + 1}": coordinator.get_scheduling_api(serial)
+    periodic_schedule_read = {
+        f"inverter_{idx + 1}": coordinator.get_periodic_read_state(serial)
         for idx, serial in enumerate(coordinator.data or {})
     }
 
@@ -61,7 +61,7 @@ async def async_get_config_entry_diagnostics(
             "inverter_count": coordinator.inverter_count,
             "model_list": coordinator.model_list,
             "has_throttle": coordinator.has_throttle,
-            "scheduling_api": scheduling_api,
+            "periodic_schedule_read": periodic_schedule_read,
         },
         "data": inverters,
     }

--- a/custom_components/alphaess/diagnostics.py
+++ b/custom_components/alphaess/diagnostics.py
@@ -39,6 +39,12 @@ async def async_get_config_entry_diagnostics(
         for idx, values in enumerate((coordinator.data or {}).values())
     }
 
+    # Keyed the same way so it lines up with the anonymised data above
+    scheduling_api = {
+        f"inverter_{idx + 1}": coordinator.get_scheduling_api(serial)
+        for idx, serial in enumerate(coordinator.data or {})
+    }
+
     return {
         "entry": {
             "data": async_redact_data(dict(entry.data), TO_REDACT_CONFIG),
@@ -55,6 +61,7 @@ async def async_get_config_entry_diagnostics(
             "inverter_count": coordinator.inverter_count,
             "model_list": coordinator.model_list,
             "has_throttle": coordinator.has_throttle,
+            "scheduling_api": scheduling_api,
         },
         "data": inverters,
     }

--- a/custom_components/alphaess/enums.py
+++ b/custom_components/alphaess/enums.py
@@ -122,4 +122,4 @@ class AlphaESSNames(str, Enum):
     LastPollType = "Last Poll Type"
     LastFullPoll = "Last Full Poll"
     PollTickCount = "Poll Tick Count"
-    SchedulingApi = "Scheduling API"
+    PeriodicScheduleRead = "Periodic Schedule Read"

--- a/custom_components/alphaess/enums.py
+++ b/custom_components/alphaess/enums.py
@@ -122,3 +122,4 @@ class AlphaESSNames(str, Enum):
     LastPollType = "Last Poll Type"
     LastFullPoll = "Last Full Poll"
     PollTickCount = "Poll Tick Count"
+    SchedulingApi = "Scheduling API"

--- a/custom_components/alphaess/manifest.json
+++ b/custom_components/alphaess/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/CharlesGillanders/homeassistant-alphaESS/issues",
   "loggers": ["alphaess"],
   "requirements": [
-    "alphaessopenapi==0.0.19"
+    "alphaessopenapi==0.0.20"
   ],
-  "version": "0.8.5"
+  "version": "0.9.0"
 }

--- a/custom_components/alphaess/manifest.json
+++ b/custom_components/alphaess/manifest.json
@@ -12,7 +12,7 @@
   "issue_tracker": "https://github.com/CharlesGillanders/homeassistant-alphaESS/issues",
   "loggers": ["alphaess"],
   "requirements": [
-    "alphaessopenapi==0.0.20"
+    "alphaessopenapi==0.0.21"
   ],
   "version": "0.9.0"
 }

--- a/custom_components/alphaess/number.py
+++ b/custom_components/alphaess/number.py
@@ -156,19 +156,29 @@ class AlphaNumber(CoordinatorEntity, RestoreNumber):
         )
 
     async def async_set_native_value(self, value: float) -> None:
+        previous_value = self._attr_native_value
         self._attr_native_value = value
         self.save_value(value)
         self.async_write_ha_state()
 
         # Push to API
-        if self.key is AlphaESSNames.batHighCap:
-            await self._coordinator.async_write_charge_config(
-                self._serial, bat_high_cap=value,
-            )
-        elif self.key is AlphaESSNames.batUseCap:
-            await self._coordinator.async_write_discharge_config(
-                self._serial, bat_use_cap=value,
-            )
+        try:
+            if self.key is AlphaESSNames.batHighCap:
+                await self._coordinator.async_write_charge_config(
+                    self._serial, bat_high_cap=value,
+                )
+            elif self.key is AlphaESSNames.batUseCap:
+                await self._coordinator.async_write_discharge_config(
+                    self._serial, bat_use_cap=value,
+                )
+        except Exception:
+            # Nothing was written, so put the stored value back too -- it is
+            # what the charge/discharge buttons will send next time.
+            _LOGGER.exception("Failed to set %s for %s, reverting", self._name, self._serial)
+            self._attr_native_value = previous_value
+            self.save_value(previous_value)
+            self.async_write_ha_state()
+            return
 
         await self._coordinator.async_request_refresh()
 

--- a/custom_components/alphaess/number.py
+++ b/custom_components/alphaess/number.py
@@ -161,32 +161,14 @@ class AlphaNumber(CoordinatorEntity, RestoreNumber):
         self.async_write_ha_state()
 
         # Push to API
-        data = self._coordinator.data.get(self._serial, {})
-
         if self.key is AlphaESSNames.batHighCap:
-            grid_charge = data.get("gridCharge", 1)
-            result = await self._coordinator.api.updateChargeConfigInfo(
-                self._serial,
-                value,
-                grid_charge,
-                data.get("charge_timeChae1") or "00:00",
-                data.get("charge_timeChae2") or "00:00",
-                data.get("charge_timeChaf1") or "00:00",
-                data.get("charge_timeChaf2") or "00:00",
+            await self._coordinator.async_write_charge_config(
+                self._serial, bat_high_cap=value,
             )
-            _LOGGER.info("Updated batHighCap for %s to %s - Result: %s", self._serial, value, result)
         elif self.key is AlphaESSNames.batUseCap:
-            ctr_dis = data.get("ctrDis", 1)
-            result = await self._coordinator.api.updateDisChargeConfigInfo(
-                self._serial,
-                value,
-                ctr_dis,
-                data.get("discharge_timeDise1") or "00:00",
-                data.get("discharge_timeDise2") or "00:00",
-                data.get("discharge_timeDisf1") or "00:00",
-                data.get("discharge_timeDisf2") or "00:00",
+            await self._coordinator.async_write_discharge_config(
+                self._serial, bat_use_cap=value,
             )
-            _LOGGER.info("Updated batUseCap for %s to %s - Result: %s", self._serial, value, result)
 
         await self._coordinator.async_request_refresh()
 

--- a/custom_components/alphaess/number.py
+++ b/custom_components/alphaess/number.py
@@ -173,10 +173,15 @@ class AlphaNumber(CoordinatorEntity, RestoreNumber):
                 )
         except Exception:
             # Nothing was written, so put the stored value back too -- it is
-            # what the charge/discharge buttons will send next time.
+            # what the charge/discharge buttons will send next time. With no
+            # previous value, drop the key entirely rather than storing None,
+            # which would shadow the default those callers fall back to.
             _LOGGER.exception("Failed to set %s for %s, reverting", self._name, self._serial)
             self._attr_native_value = previous_value
-            self.save_value(previous_value)
+            if previous_value is None:
+                self._coordinator.clear_number_setting(self._serial, self._name)
+            else:
+                self.save_value(previous_value)
             self.async_write_ha_state()
             return
 

--- a/custom_components/alphaess/sensorlist.py
+++ b/custom_components/alphaess/sensorlist.py
@@ -123,6 +123,18 @@ _COMMON_DAILY_SENSORS: list[AlphaESSSensorDescription] = [
         state_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
+    # Which charge/discharge scheduling API this system accepts. "periodic"
+    # means the newer setTimeChargeBySn backend is in use (and written to
+    # alongside the legacy endpoints); "legacy" means only the old endpoints
+    # work here. See issues #267 and #269.
+    AlphaESSSensorDescription(
+        key=AlphaESSNames.SchedulingApi,
+        name="Scheduling API",
+        icon="mdi:calendar-clock",
+        native_unit_of_measurement=None,
+        state_class=None,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
 ]
 
 FULL_SENSOR_DESCRIPTIONS: list[AlphaESSSensorDescription] = [

--- a/custom_components/alphaess/sensorlist.py
+++ b/custom_components/alphaess/sensorlist.py
@@ -123,13 +123,12 @@ _COMMON_DAILY_SENSORS: list[AlphaESSSensorDescription] = [
         state_class=None,
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
-    # Which charge/discharge scheduling API this system accepts. "periodic"
-    # means the newer setTimeChargeBySn backend is in use (and written to
-    # alongside the legacy endpoints); "legacy" means only the old endpoints
-    # work here. See issues #267 and #269.
+    # Whether getTimeChargeBySn can be read on this account. Diagnostic only:
+    # "unreadable" does not mean the system is on the old backend, and both
+    # scheduling APIs are written regardless. See issues #267 and #269.
     AlphaESSSensorDescription(
-        key=AlphaESSNames.SchedulingApi,
-        name="Scheduling API",
+        key=AlphaESSNames.PeriodicScheduleRead,
+        name="Periodic Schedule Read",
         icon="mdi:calendar-clock",
         native_unit_of_measurement=None,
         state_class=None,

--- a/custom_components/alphaess/switch.py
+++ b/custom_components/alphaess/switch.py
@@ -1,5 +1,4 @@
 """Switch platform for AlphaESS integration."""
-import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -13,8 +12,6 @@ from .const import (
 from .coordinator import AlphaESSDataUpdateCoordinator
 from .device import build_inverter_device_info
 from .sensorlist import CHARGE_DISCHARGE_SWITCHES
-
-_LOGGER = logging.getLogger(__name__)
 
 # Serialize switch writes; the AlphaESS API rate-limits config writes.
 PARALLEL_UPDATES = 1

--- a/custom_components/alphaess/switch.py
+++ b/custom_components/alphaess/switch.py
@@ -12,7 +12,6 @@ from .const import (
 )
 from .coordinator import AlphaESSDataUpdateCoordinator
 from .device import build_inverter_device_info
-from .enums import AlphaESSNames
 from .sensorlist import CHARGE_DISCHARGE_SWITCHES
 
 _LOGGER = logging.getLogger(__name__)
@@ -108,37 +107,13 @@ class AlphaSwitch(CoordinatorEntity, SwitchEntity):
 
     async def _set_value(self, value: int) -> None:
         """Send the updated config to the API."""
-        data = self._coordinator.data.get(self._serial, {})
-
         if self._coordinator_key == "gridCharge":
-            bat_high_cap = data.get(AlphaESSNames.batHighCap, 90)
-            result = await self._coordinator.api.updateChargeConfigInfo(
-                self._serial,
-                bat_high_cap,
-                value,
-                data.get("charge_timeChae1") or "00:00",
-                data.get("charge_timeChae2") or "00:00",
-                data.get("charge_timeChaf1") or "00:00",
-                data.get("charge_timeChaf2") or "00:00",
-            )
-            _LOGGER.info(
-                "Updated gridCharge for %s to %s - Result: %s",
-                self._serial, value, result,
+            await self._coordinator.async_write_charge_config(
+                self._serial, grid_charge=value,
             )
         elif self._coordinator_key == "ctrDis":
-            bat_use_cap = data.get(AlphaESSNames.batUseCap, 10)
-            result = await self._coordinator.api.updateDisChargeConfigInfo(
-                self._serial,
-                bat_use_cap,
-                value,
-                data.get("discharge_timeDise1") or "00:00",
-                data.get("discharge_timeDise2") or "00:00",
-                data.get("discharge_timeDisf1") or "00:00",
-                data.get("discharge_timeDisf2") or "00:00",
-            )
-            _LOGGER.info(
-                "Updated ctrDis for %s to %s - Result: %s",
-                self._serial, value, result,
+            await self._coordinator.async_write_discharge_config(
+                self._serial, ctr_dis=value,
             )
 
         # No immediate refresh — optimistic state is shown until the next

--- a/custom_components/alphaess/switch.py
+++ b/custom_components/alphaess/switch.py
@@ -1,4 +1,5 @@
 """Switch platform for AlphaESS integration."""
+import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
@@ -12,6 +13,8 @@ from .const import (
 from .coordinator import AlphaESSDataUpdateCoordinator
 from .device import build_inverter_device_info
 from .sensorlist import CHARGE_DISCHARGE_SWITCHES
+
+_LOGGER = logging.getLogger(__name__)
 
 # Serialize switch writes; the AlphaESS API rate-limits config writes.
 PARALLEL_UPDATES = 1
@@ -92,26 +95,34 @@ class AlphaSwitch(CoordinatorEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on (enable) the setting."""
-        self._optimistic_state = True
-        self.async_write_ha_state()
         await self._set_value(1)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off (disable) the setting."""
-        self._optimistic_state = False
-        self.async_write_ha_state()
         await self._set_value(0)
 
     async def _set_value(self, value: int) -> None:
         """Send the updated config to the API."""
-        if self._coordinator_key == "gridCharge":
-            await self._coordinator.async_write_charge_config(
-                self._serial, grid_charge=value,
-            )
-        elif self._coordinator_key == "ctrDis":
-            await self._coordinator.async_write_discharge_config(
-                self._serial, ctr_dis=value,
-            )
+        previous_state = self._optimistic_state
+        self._optimistic_state = bool(value)
+        self.async_write_ha_state()
+
+        try:
+            if self._coordinator_key == "gridCharge":
+                await self._coordinator.async_write_charge_config(
+                    self._serial, grid_charge=value,
+                )
+            elif self._coordinator_key == "ctrDis":
+                await self._coordinator.async_write_discharge_config(
+                    self._serial, ctr_dis=value,
+                )
+        except Exception:
+            # Nothing was written, so don't leave the UI claiming otherwise.
+            _LOGGER.exception("Failed to update %s for %s, reverting",
+                              self._coordinator_key, self._serial)
+            self._optimistic_state = previous_state
+            self.async_write_ha_state()
+            return
 
         # No immediate refresh — optimistic state is shown until the next
         # scheduled coordinator update confirms the value from the API.

--- a/custom_components/alphaess/time.py
+++ b/custom_components/alphaess/time.py
@@ -8,7 +8,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import CONF_SERIAL_NUMBER, INVERTER_SETTING_BLACKLIST, SUBENTRY_TYPE_INVERTER
 from .coordinator import AlphaESSDataUpdateCoordinator
 from .device import build_inverter_device_info
-from .enums import AlphaESSNames
 from .sensorlist import CHARGE_DISCHARGE_TIMES
 
 _LOGGER = logging.getLogger(__name__)
@@ -16,21 +15,19 @@ _LOGGER = logging.getLogger(__name__)
 # Serialize time writes; the AlphaESS API rate-limits config writes.
 PARALLEL_UPDATES = 1
 
-# Mapping from coordinator key to the API parameter position
-# Charge API: updateChargeConfigInfo(serial, batHighCap, gridCharge, timeChae1, timeChae2, timeChaf1, timeChaf2)
-# Discharge API: updateDisChargeConfigInfo(serial, batUseCap, ctrDis, timeDise1, timeDise2, timeDisf1, timeDisf2)
+# Coordinator key -> the legacy API field the coordinator writers expect.
 CHARGE_TIME_KEYS = {
-    "charge_timeChaf1",
-    "charge_timeChae1",
-    "charge_timeChaf2",
-    "charge_timeChae2",
+    "charge_timeChaf1": "timeChaf1",
+    "charge_timeChae1": "timeChae1",
+    "charge_timeChaf2": "timeChaf2",
+    "charge_timeChae2": "timeChae2",
 }
 
 DISCHARGE_TIME_KEYS = {
-    "discharge_timeDisf1",
-    "discharge_timeDise1",
-    "discharge_timeDisf2",
-    "discharge_timeDise2",
+    "discharge_timeDisf1": "timeDisf1",
+    "discharge_timeDise1": "timeDise1",
+    "discharge_timeDisf2": "timeDisf2",
+    "discharge_timeDise2": "timeDise2",
 }
 
 
@@ -127,9 +124,15 @@ class AlphaTime(CoordinatorEntity, TimeEntity):
 
         try:
             if self._coordinator_key in CHARGE_TIME_KEYS:
-                await self._update_charge_config(time_str)
+                await self._coordinator.async_write_charge_config(
+                    self._serial,
+                    times={CHARGE_TIME_KEYS[self._coordinator_key]: time_str},
+                )
             elif self._coordinator_key in DISCHARGE_TIME_KEYS:
-                await self._update_discharge_config(time_str)
+                await self._coordinator.async_write_discharge_config(
+                    self._serial,
+                    times={DISCHARGE_TIME_KEYS[self._coordinator_key]: time_str},
+                )
         except Exception:
             _LOGGER.exception("Failed to update time for %s, reverting", self._coordinator_key)
             self._attr_native_value = previous_value
@@ -137,88 +140,6 @@ class AlphaTime(CoordinatorEntity, TimeEntity):
             return
 
         await self._coordinator.async_request_refresh()
-
-    async def _update_charge_config(self, new_time_str: str) -> None:
-        """Send updated charge config to the API."""
-        data = self._coordinator.data.get(self._serial, {})
-
-        # Read current values
-        current = {
-            "timeChaf1": data.get("charge_timeChaf1") or "00:00",
-            "timeChae1": data.get("charge_timeChae1") or "00:00",
-            "timeChaf2": data.get("charge_timeChaf2") or "00:00",
-            "timeChae2": data.get("charge_timeChae2") or "00:00",
-        }
-
-        # Map coordinator key to API parameter
-        key_map = {
-            "charge_timeChaf1": "timeChaf1",
-            "charge_timeChae1": "timeChae1",
-            "charge_timeChaf2": "timeChaf2",
-            "charge_timeChae2": "timeChae2",
-        }
-
-        api_key = key_map[self._coordinator_key]
-        current[api_key] = new_time_str
-
-        bat_high_cap = data.get(AlphaESSNames.batHighCap, 90)
-        grid_charge = data.get("gridCharge", 1)
-
-        result = await self._coordinator.api.updateChargeConfigInfo(
-            self._serial,
-            bat_high_cap,
-            grid_charge,
-            current["timeChae1"],
-            current["timeChae2"],
-            current["timeChaf1"],
-            current["timeChaf2"],
-        )
-
-        _LOGGER.info(
-            "Updated charge config for %s: %s=%s, Result: %s",
-            self._serial, self._coordinator_key, new_time_str, result,
-        )
-
-    async def _update_discharge_config(self, new_time_str: str) -> None:
-        """Send updated discharge config to the API."""
-        data = self._coordinator.data.get(self._serial, {})
-
-        # Read current values
-        current = {
-            "timeDisf1": data.get("discharge_timeDisf1") or "00:00",
-            "timeDise1": data.get("discharge_timeDise1") or "00:00",
-            "timeDisf2": data.get("discharge_timeDisf2") or "00:00",
-            "timeDise2": data.get("discharge_timeDise2") or "00:00",
-        }
-
-        # Map coordinator key to API parameter
-        key_map = {
-            "discharge_timeDisf1": "timeDisf1",
-            "discharge_timeDise1": "timeDise1",
-            "discharge_timeDisf2": "timeDisf2",
-            "discharge_timeDise2": "timeDise2",
-        }
-
-        api_key = key_map[self._coordinator_key]
-        current[api_key] = new_time_str
-
-        bat_use_cap = data.get(AlphaESSNames.batUseCap, 10)
-        ctr_dis = data.get("ctrDis", 1)
-
-        result = await self._coordinator.api.updateDisChargeConfigInfo(
-            self._serial,
-            bat_use_cap,
-            ctr_dis,
-            current["timeDise1"],
-            current["timeDise2"],
-            current["timeDisf1"],
-            current["timeDisf2"],
-        )
-
-        _LOGGER.info(
-            "Updated discharge config for %s: %s=%s, Result: %s",
-            self._serial, self._coordinator_key, new_time_str, result,
-        )
 
     @property
     def available(self) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,8 @@ def mock_api():
         "getIPData",
         "updateChargeConfigInfo",
         "updateDisChargeConfigInfo",
+        "getTimeChargeBySn",
+        "setTimeChargeBySn",
         "setEvChargerCurrentsBySn",
         "remoteControlEvCharger",
         "getVerificationCode",

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -189,6 +189,32 @@ class TestEntitiesRevertOnRejection:
         assert number._attr_native_value == 90.0
         assert coordinator.get_number_setting(SERIAL, "batHighCap") == 90.0
 
+    async def test_number_revert_does_not_shadow_the_default(
+        self, make_coordinator, mock_api
+    ):
+        """Reverting to "no value yet" must not store None.
+
+        get_number_setting falls back only when the key is absent, so a stored
+        None would be handed to the API in place of the 90/10 default.
+        """
+        from custom_components.alphaess.enums import AlphaESSNames
+        from custom_components.alphaess.number import AlphaNumber
+
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        description = MagicMock(key=AlphaESSNames.batHighCap, entity_category=None,
+                                native_unit_of_measurement="%", icon=None)
+        description.name = "batHighCap"
+        number = AlphaNumber(coordinator, SERIAL, FakeEntry(), description)
+        number.async_write_ha_state = MagicMock()
+        number._attr_native_value = None
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6042)
+
+        await number.async_set_native_value(55.0)
+
+        assert coordinator.get_number_setting(SERIAL, "batHighCap", 90) == 90
+
 
 class TestServicesReportCleanly:
     """A rejection should read as an HA error, not a raw library traceback."""

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -31,6 +31,32 @@ def _api_error(code, expMsg=None):
                             description="desc")
 
 
+class TestErrorDescriptions:
+    """Codes are rendered with the library's own wording, not a local copy."""
+
+    def test_known_code_shows_its_meaning(self):
+        from alphaess.alphaess import UNDOCUMENTED_RETURN_CODES
+
+        from custom_components.alphaess.coordinator import describe_api_error
+
+        err = AlphaESSApiError(
+            code=6017, msg="No operation permissions",
+            description=UNDOCUMENTED_RETURN_CODES[6017])
+        assert describe_api_error(err) == "6017 (No operation permissions)"
+
+    def test_expmsg_is_appended_when_present(self):
+        err = AlphaESSApiError(code=6001, description="Parameter error",
+                               expMsg="time list is null")
+        from custom_components.alphaess.coordinator import describe_api_error
+
+        assert describe_api_error(err) == "6001 (Parameter error) - time list is null"
+
+    def test_unknown_code_still_shows_the_number(self):
+        from custom_components.alphaess.coordinator import describe_api_error
+
+        assert describe_api_error(AlphaESSApiError(code=9999)) == "9999"
+
+
 class TestReadsStayTolerant:
     """A refused read must not take the whole inverter down with it.
 

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -6,11 +6,16 @@ exceptions everywhere, including on reads that used to just return None — thes
 tests pin down which paths absorb them and which don't.
 """
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from alphaess.alphaess import AlphaESSApiError
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 
 import custom_components.alphaess as init_mod
 from custom_components.alphaess import async_setup_entry
@@ -113,6 +118,206 @@ class TestWriteDetectsRejection:
         """No exception means the API took it -- previously unknowable."""
         assert await coordinator._async_write_periodic_schedule(
             SERIAL, coordinator._current_schedule_state(SERIAL)) is True
+
+
+class TestEntitiesRevertOnRejection:
+    """A refused write must not leave the UI showing a value that never landed."""
+
+    async def test_switch_reverts(self, make_coordinator, mock_api):
+        from custom_components.alphaess.switch import AlphaSwitch
+
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        # MagicMock(name=...) names the mock rather than setting .name
+        description = MagicMock(icon=None, entity_category=None,
+                                coordinator_key="gridCharge")
+        description.name = "Grid Charge Enabled"
+        switch = AlphaSwitch(coordinator, SERIAL, FakeEntry(), description)
+        switch.async_write_ha_state = MagicMock()
+        switch._optimistic_state = False
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6042)
+
+        await switch.async_turn_on()
+
+        assert switch._optimistic_state is False
+
+    async def test_number_reverts_stored_value_too(self, make_coordinator, mock_api):
+        """The stored value is what the charge/discharge buttons send next."""
+        from custom_components.alphaess.enums import AlphaESSNames
+        from custom_components.alphaess.number import AlphaNumber
+
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        description = MagicMock(key=AlphaESSNames.batHighCap, entity_category=None,
+                                native_unit_of_measurement="%", icon=None)
+        description.name = "batHighCap"
+        number = AlphaNumber(coordinator, SERIAL, FakeEntry(), description)
+        number.async_write_ha_state = MagicMock()
+        number._attr_native_value = 90.0
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6042)
+
+        await number.async_set_native_value(55.0)
+
+        assert number._attr_native_value == 90.0
+        assert coordinator.get_number_setting(SERIAL, "batHighCap") == 90.0
+
+
+class TestServicesReportCleanly:
+    """A rejection should read as an HA error, not a raw library traceback."""
+
+    def _call(self, mock_hass, coordinator, data):
+        entry = FakeEntry()
+        entry.runtime_data = coordinator
+        mock_hass.config_entries.async_entries.return_value = [entry]
+        return SimpleNamespace(hass=mock_hass, data=data)
+
+    async def test_charge_service(self, mock_hass, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6042)
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        call = self._call(mock_hass, coordinator, {
+            "serial": SERIAL, "chargestopsoc": 90, "enabled": True,
+            "cp1start": "01:00", "cp1end": "05:00",
+            "cp2start": "00:00", "cp2end": "00:00",
+        })
+
+        with pytest.raises(HomeAssistantError, match="rejected the charge settings"):
+            await init_mod._async_service_battery_charge(call)
+
+    async def test_discharge_service(self, mock_hass, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6042)
+        mock_api.updateDisChargeConfigInfo.side_effect = _api_error(6042)
+        call = self._call(mock_hass, coordinator, {
+            "serial": SERIAL, "dischargecutoffsoc": 10, "enabled": True,
+            "dp1start": "18:00", "dp1end": "22:00",
+            "dp2start": "00:00", "dp2end": "00:00",
+        })
+
+        with pytest.raises(HomeAssistantError, match="rejected the discharge settings"):
+            await init_mod._async_service_battery_discharge(call)
+
+
+class TestButtonsDoNotBurnTheRateLimit:
+    """A refused command shouldn't cost the user a 30 second cooldown."""
+
+    def _button(self, coordinator, key, name, notify=False):
+        from custom_components.alphaess.button import AlphaESSBatteryButton
+        from custom_components.alphaess.const import CONF_DISABLE_NOTIFICATIONS
+
+        description = MagicMock(key=key, icon=None, entity_category=None)
+        description.name = name
+
+        subentry = None
+        if notify:
+            subentry = MagicMock(subentry_id="sub-1")
+            subentry.data = {CONF_DISABLE_NOTIFICATIONS: False}
+
+        button = AlphaESSBatteryButton(
+            coordinator, FakeEntry(), SERIAL, description, subentry=subentry)
+        button.hass = MagicMock()
+        button.hass.services.async_call = AsyncMock()
+        if notify:
+            entry = MagicMock()
+            entry.subentries = {"sub-1": subentry}
+            button.hass.config_entries.async_get_entry = MagicMock(return_value=entry)
+        return button
+
+    def _notifications(self, button):
+        return [c for c in button.hass.services.async_call.await_args_list
+                if c.args[:2] == ("persistent_notification", "create")]
+
+    async def test_timed_command_rejection_restores_the_timestamp(
+        self, make_coordinator, mock_api
+    ):
+        from custom_components.alphaess.enums import AlphaESSNames
+
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6042)
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        button = self._button(coordinator, AlphaESSNames.ButtonChargeThirty, "30 Minute Charge")
+
+        await button.async_press()
+
+        assert coordinator.last_charge_update.get(SERIAL) is None
+
+    async def test_reset_rejection_restores_both_timestamps(self, make_coordinator, mock_api):
+        from custom_components.alphaess.enums import AlphaESSNames
+
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        button = self._button(coordinator, AlphaESSNames.ButtonRechargeConfig, "Reset Config")
+
+        await button.async_press()
+
+        assert coordinator.last_charge_update.get(SERIAL) is None
+        assert coordinator.last_discharge_update.get(SERIAL) is None
+
+    async def test_failures_are_notified_when_notifications_are_on(
+        self, make_coordinator, mock_api
+    ):
+        from custom_components.alphaess.enums import AlphaESSNames
+
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6042)
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        button = self._button(coordinator, AlphaESSNames.ButtonChargeThirty,
+                              "30 Minute Charge", notify=True)
+
+        await button.async_press()
+
+        notifications = self._notifications(button)
+        assert notifications, "expected a failure notification"
+        assert "rejected" in notifications[-1].args[2]["message"]
+
+    async def test_reset_failure_is_notified(self, make_coordinator, mock_api):
+        from custom_components.alphaess.enums import AlphaESSNames
+
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.updateChargeConfigInfo.side_effect = _api_error(6042)
+        button = self._button(coordinator, AlphaESSNames.ButtonRechargeConfig,
+                              "Reset Config", notify=True)
+
+        await button.async_press()
+
+        notifications = self._notifications(button)
+        assert notifications
+        assert "Reset failed" in notifications[-1].args[2]["title"]
+
+
+class TestConfigFlowRejectsBadCredentials:
+    """Previously a wrong AppSecret still created an entry."""
+
+    async def _validate(self, mock_hass, monkeypatch, err):
+        from custom_components.alphaess import config_flow as cf
+
+        client = MagicMock()
+        client.authenticate = AsyncMock(side_effect=err)
+        client.getESSList = AsyncMock()
+        monkeypatch.setattr(cf.alphaess, "alphaess", MagicMock(return_value=client))
+        monkeypatch.setattr(cf, "async_get_clientsession", MagicMock())
+        return await cf.validate_input(
+            mock_hass, {"AppID": "id", "AppSecret": "secret"})
+
+    async def test_sign_failure_is_invalid_auth(self, mock_hass, monkeypatch):
+        from custom_components.alphaess.config_flow import InvalidAuth
+
+        with pytest.raises(InvalidAuth):
+            await self._validate(mock_hass, monkeypatch, _api_error(6007))
+
+    async def test_other_codes_are_cannot_connect(self, mock_hass, monkeypatch):
+        from custom_components.alphaess.config_flow import CannotConnect
+
+        with pytest.raises(CannotConnect):
+            await self._validate(mock_hass, monkeypatch, _api_error(6042))
 
 
 class TestSetupHandlesRejection:

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,0 +1,138 @@
+"""Tests for AlphaESSApiError handling.
+
+The client runs with raise_on_error=True so schedule writes can tell an accepted
+schedule from a rejected one. That means API-level rejections now arrive as
+exceptions everywhere, including on reads that used to just return None — these
+tests pin down which paths absorb them and which don't.
+"""
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from alphaess.alphaess import AlphaESSApiError
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+
+import custom_components.alphaess as init_mod
+from custom_components.alphaess import async_setup_entry
+from custom_components.alphaess.coordinator import PERIODIC_NOT_ENTITLED
+
+from .conftest import FakeEntry
+from .test_periodic_schedule import SERIAL, _schedule_data
+
+
+def _api_error(code, expMsg=None):
+    return AlphaESSApiError(code=code, msg="rejected", expMsg=expMsg,
+                            path="https://openapi.alphaess.com/api/x",
+                            description="desc")
+
+
+class TestReadsStayTolerant:
+    """A refused read must not take the whole inverter down with it.
+
+    Before raise_on_error these returned None and the sensor simply went
+    missing. That has to stay true, otherwise an endpoint the account isn't
+    entitled to would abort the fetch and trip the per-inverter error backoff.
+    """
+
+    async def test_read_swallows_api_error_and_returns_none(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        mock_api.getChargeConfigInfo.side_effect = _api_error(6017)
+
+        assert await coordinator._read(mock_api.getChargeConfigInfo, SERIAL) is None
+
+    async def test_read_lets_transport_errors_through(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        mock_api.getChargeConfigInfo.side_effect = OSError("connection reset")
+
+        with pytest.raises(OSError):
+            await coordinator._read(mock_api.getChargeConfigInfo, SERIAL)
+
+    async def test_refused_endpoint_does_not_fail_the_poll(self, make_coordinator, mock_api):
+        """One dead endpoint should cost one value, not the whole inverter."""
+        mock_api.getESSList.return_value = [{"sysSn": SERIAL, "minv": "SMILE5-INV"}]
+        mock_api.getChargeConfigInfo.side_effect = _api_error(6017)
+        coordinator = make_coordinator(models=["SMILE5-INV"])
+
+        result = await coordinator._async_update_data()
+
+        assert SERIAL in result
+        assert coordinator._inverter_error_count.get(SERIAL, 0) == 0
+        assert coordinator.cloud_available is True
+
+
+class TestProbeDistinguishesRejections:
+    async def test_6017_is_cached_as_unreadable(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        mock_api.getTimeChargeBySn.side_effect = _api_error(PERIODIC_NOT_ENTITLED)
+
+        assert await coordinator.async_probe_periodic_readable(SERIAL) is False
+        assert coordinator._periodic_readable[SERIAL] is False
+
+    async def test_other_codes_leave_the_answer_open(self, make_coordinator, mock_api):
+        """6042 "system offline" could well succeed on the next poll."""
+        coordinator = make_coordinator()
+        mock_api.getTimeChargeBySn.side_effect = _api_error(6042)
+
+        assert await coordinator.async_probe_periodic_readable(SERIAL) is None
+        assert SERIAL not in coordinator._periodic_readable
+
+
+class TestWriteDetectsRejection:
+    @pytest.fixture
+    def coordinator(self, make_coordinator):
+        c = make_coordinator()
+        c.data = {SERIAL: _schedule_data()}
+        c._periodic_readable[SERIAL] = True
+        return c
+
+    async def test_6017_stops_further_attempts(self, coordinator, mock_api, caplog):
+        caplog.set_level(logging.INFO)
+        mock_api.setTimeChargeBySn.side_effect = _api_error(PERIODIC_NOT_ENTITLED)
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
+        assert SERIAL in coordinator._periodic_write_denied
+        assert "not entitled" in caplog.text
+
+        mock_api.setTimeChargeBySn.reset_mock()
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+        # The legacy endpoint still gets written both times.
+        assert mock_api.updateChargeConfigInfo.await_count == 2
+
+    async def test_other_rejections_are_logged_with_expmsg(self, coordinator, mock_api, caplog):
+        mock_api.setTimeChargeBySn.side_effect = _api_error(6001, expMsg="time list is null")
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
+
+        assert "time list is null" in caplog.text
+        # Not permanent, so keep trying on the next write.
+        assert SERIAL not in coordinator._periodic_write_denied
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+
+    async def test_acceptance_now_means_something(self, coordinator, mock_api):
+        """No exception means the API took it -- previously unknowable."""
+        assert await coordinator._async_write_periodic_schedule(
+            SERIAL, coordinator._current_schedule_state(SERIAL)) is True
+
+
+class TestSetupHandlesRejection:
+    def _entry(self):
+        entry = FakeEntry()
+        entry.options = {}
+        return entry
+
+    async def _run(self, mock_hass, monkeypatch, err):
+        client = MagicMock()
+        client.getESSList = AsyncMock(side_effect=err)
+        monkeypatch.setattr(init_mod.alphaess, "alphaess", MagicMock(return_value=client))
+        monkeypatch.setattr(init_mod, "async_get_clientsession", MagicMock())
+        return await async_setup_entry(mock_hass, self._entry())
+
+    async def test_credential_codes_raise_auth_failed(self, mock_hass, monkeypatch):
+        """Bad credentials come back as a return code, not an HTTP 401."""
+        with pytest.raises(ConfigEntryAuthFailed):
+            await self._run(mock_hass, monkeypatch, _api_error(6007))
+
+    async def test_other_codes_raise_not_ready(self, mock_hass, monkeypatch):
+        with pytest.raises(ConfigEntryNotReady):
+            await self._run(mock_hass, monkeypatch, _api_error(6042))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,7 +16,7 @@ from custom_components.alphaess import (
     _cleanup_stale_ev_entities,
     _has_inverter_subentries,
     _migrate_entity_ids,
-    _resolve_client_for_serial,
+    _resolve_coordinator_for_serial,
     async_migrate_entry,
     async_setup_entry,
     async_unload_entry,
@@ -197,7 +197,7 @@ class TestCleanupStaleEvEntities:
         ent_reg.async_remove.assert_not_called()
 
 
-class TestResolveClient:
+class TestResolveCoordinator:
     def test_resolves_by_serial(self, mock_hass, make_coordinator):
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: {}}
@@ -205,7 +205,7 @@ class TestResolveClient:
         entry.runtime_data = coordinator
         mock_hass.config_entries.async_entries.return_value = [entry]
 
-        assert _resolve_client_for_serial(mock_hass, SERIAL) is coordinator.api
+        assert _resolve_coordinator_for_serial(mock_hass, SERIAL) is coordinator
 
     def test_falls_back_to_first_coordinator(self, mock_hass, make_coordinator):
         coordinator = make_coordinator()
@@ -214,7 +214,7 @@ class TestResolveClient:
         entry.runtime_data = coordinator
         mock_hass.config_entries.async_entries.return_value = [entry]
 
-        assert _resolve_client_for_serial(mock_hass, SERIAL) is coordinator.api
+        assert _resolve_coordinator_for_serial(mock_hass, SERIAL) is coordinator
 
     def test_ignores_non_coordinator_runtime_data(self, mock_hass):
         entry = FakeEntry()
@@ -222,12 +222,12 @@ class TestResolveClient:
         mock_hass.config_entries.async_entries.return_value = [entry]
 
         with pytest.raises(HomeAssistantError):
-            _resolve_client_for_serial(mock_hass, SERIAL)
+            _resolve_coordinator_for_serial(mock_hass, SERIAL)
 
     def test_raises_without_entries(self, mock_hass):
         mock_hass.config_entries.async_entries.return_value = []
         with pytest.raises(HomeAssistantError):
-            _resolve_client_for_serial(mock_hass, SERIAL)
+            _resolve_coordinator_for_serial(mock_hass, SERIAL)
 
 
 class TestServices:
@@ -361,6 +361,7 @@ class FakeCoordinator:
         self.data = dict(type(self).next_data)
         self.cloud_available = type(self).next_cloud_available
         self.async_config_entry_first_refresh = AsyncMock()
+        self.async_probe_periodic_support = AsyncMock(return_value=False)
         type(self).instances.append(self)
 
     next_data = {}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -361,7 +361,7 @@ class FakeCoordinator:
         self.data = dict(type(self).next_data)
         self.cloud_available = type(self).next_cloud_available
         self.async_config_entry_first_refresh = AsyncMock()
-        self.async_probe_periodic_support = AsyncMock(return_value=False)
+        self.async_probe_periodic_readable = AsyncMock(return_value=False)
         type(self).instances.append(self)
 
     next_data = {}

--- a/tests/test_periodic_schedule.py
+++ b/tests/test_periodic_schedule.py
@@ -11,6 +11,9 @@ import pytest
 
 from custom_components.alphaess.coordinator import (
     PERIODIC_DAILY,
+    SCHEDULING_API_LEGACY,
+    SCHEDULING_API_PERIODIC,
+    SCHEDULING_API_UNKNOWN,
     find_overlapping_periods,
 )
 from custom_components.alphaess.enums import AlphaESSNames
@@ -336,6 +339,36 @@ class TestFailureHandling:
 
         with pytest.raises(OSError):
             await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
+
+
+class TestSchedulingApiDiagnostic:
+    def test_reports_periodic_when_supported(self, supported):
+        assert supported.get_scheduling_api(SERIAL) == SCHEDULING_API_PERIODIC
+
+    def test_reports_legacy_when_not_entitled(self, unsupported):
+        assert unsupported.get_scheduling_api(SERIAL) == SCHEDULING_API_LEGACY
+
+    def test_reports_unknown_before_the_probe_answers(self, make_coordinator):
+        assert make_coordinator().get_scheduling_api(SERIAL) == SCHEDULING_API_UNKNOWN
+
+    def test_published_into_coordinator_data(self, supported):
+        supported._update_diagnostics()
+        assert supported.data[SERIAL][AlphaESSNames.SchedulingApi] == SCHEDULING_API_PERIODIC
+
+    async def test_unknown_support_is_retried(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.getTimeChargeBySn.return_value = {"chargeTimeList": [], "dischargeTimeList": []}
+
+        await coordinator._async_resolve_unknown_scheduling_api()
+
+        mock_api.getTimeChargeBySn.assert_awaited_once_with(SERIAL)
+        assert coordinator.get_scheduling_api(SERIAL) == SCHEDULING_API_PERIODIC
+
+    async def test_known_support_is_not_reprobed(self, supported, mock_api):
+        await supported._async_resolve_unknown_scheduling_api()
+
+        mock_api.getTimeChargeBySn.assert_not_awaited()
 
 
 class TestButtonAndResetPaths:

--- a/tests/test_periodic_schedule.py
+++ b/tests/test_periodic_schedule.py
@@ -2,7 +2,8 @@
 
 Covers the dual-write behaviour added for issues #267 and #269: every schedule
 change is pushed to the periodic API first (the only one migrated AlphaESS
-backends act on) and then to the legacy two-slot endpoints.
+backends act on) and then to the legacy two-slot endpoints — unconditionally,
+because which backend a system is on cannot be detected up front.
 """
 import asyncio
 from unittest.mock import AsyncMock
@@ -11,9 +12,9 @@ import pytest
 
 from custom_components.alphaess.coordinator import (
     PERIODIC_DAILY,
-    SCHEDULING_API_LEGACY,
-    SCHEDULING_API_PERIODIC,
-    SCHEDULING_API_UNKNOWN,
+    PERIODIC_READ_OK,
+    PERIODIC_READ_UNAVAILABLE,
+    PERIODIC_READ_UNKNOWN,
     find_overlapping_periods,
 )
 from custom_components.alphaess.enums import AlphaESSNames
@@ -46,20 +47,20 @@ def _schedule_data(**overrides):
 
 
 @pytest.fixture
-def supported(make_coordinator, mock_api):
-    """A coordinator whose system is entitled to the periodic API."""
+def readable(make_coordinator, mock_api):
+    """A coordinator whose system returns a periodic schedule when read."""
     coordinator = make_coordinator()
     coordinator.data = {SERIAL: _schedule_data()}
-    coordinator._periodic_support[SERIAL] = True
+    coordinator._periodic_readable[SERIAL] = True
     return coordinator
 
 
 @pytest.fixture
-def unsupported(make_coordinator, mock_api):
-    """A coordinator whose system returned 6017 (feature not entitled)."""
+def unreadable(make_coordinator, mock_api):
+    """A coordinator whose read came back 6017 "no operation permissions"."""
     coordinator = make_coordinator()
     coordinator.data = {SERIAL: _schedule_data()}
-    coordinator._periodic_support[SERIAL] = False
+    coordinator._periodic_readable[SERIAL] = False
     return coordinator
 
 
@@ -90,40 +91,40 @@ class TestOverlapDetection:
 
 
 class TestBuildPeriodList:
-    def test_drops_disabled_slots(self, supported):
-        periods = supported._build_period_list(
+    def test_drops_disabled_slots(self, readable):
+        periods = readable._build_period_list(
             [("01:00", "05:00"), ("00:00", "00:00")], 90,
         )
         assert periods == [{"beginTime": "01:00", "endTime": "05:00", "chargeLimit": 90}]
 
-    def test_all_disabled_gives_empty_list(self, supported):
-        periods = supported._build_period_list(
+    def test_all_disabled_gives_empty_list(self, readable):
+        periods = readable._build_period_list(
             [("00:00", "00:00"), ("12:00", "12:00")], 90,
         )
         assert periods == []
 
-    def test_missing_times_are_skipped(self, supported):
-        assert supported._build_period_list([(None, "05:00"), ("01:00", None)], 90) == []
+    def test_missing_times_are_skipped(self, readable):
+        assert readable._build_period_list([(None, "05:00"), ("01:00", None)], 90) == []
 
-    def test_charge_limit_clamped_to_minimum(self, supported):
+    def test_charge_limit_clamped_to_minimum(self, readable):
         # The number entity allows 0-100 but the periodic API rejects <10 (6001).
-        periods = supported._build_period_list([("17:00", "21:00")], 5)
+        periods = readable._build_period_list([("17:00", "21:00")], 5)
         assert periods[0]["chargeLimit"] == 10
 
-    def test_charge_limit_clamped_to_maximum(self, supported):
-        periods = supported._build_period_list([("01:00", "05:00")], 150)
+    def test_charge_limit_clamped_to_maximum(self, readable):
+        periods = readable._build_period_list([("01:00", "05:00")], 150)
         assert periods[0]["chargeLimit"] == 100
 
-    def test_invalid_charge_limit_falls_back_to_minimum(self, supported):
-        periods = supported._build_period_list([("01:00", "05:00")], None)
+    def test_invalid_charge_limit_falls_back_to_minimum(self, readable):
+        periods = readable._build_period_list([("01:00", "05:00")], None)
         assert periods[0]["chargeLimit"] == 10
 
-    def test_charge_power_included_when_known(self, supported):
-        periods = supported._build_period_list([("01:00", "05:00")], 90, 5000)
+    def test_charge_power_included_when_known(self, readable):
+        periods = readable._build_period_list([("01:00", "05:00")], 90, 5000)
         assert periods[0]["chargePower"] == 5000
 
-    def test_charge_power_omitted_when_unknown(self, supported):
-        periods = supported._build_period_list([("01:00", "05:00")], 90)
+    def test_charge_power_omitted_when_unknown(self, readable):
+        periods = readable._build_period_list([("01:00", "05:00")], 90)
         assert "chargePower" not in periods[0]
 
 
@@ -135,8 +136,8 @@ class TestProbe:
             "dischargeTimeList": [],
         }
 
-        assert await coordinator.async_probe_periodic_support(SERIAL) is True
-        assert coordinator._periodic_support[SERIAL] is True
+        assert await coordinator.async_probe_periodic_readable(SERIAL) is True
+        assert coordinator._periodic_readable[SERIAL] is True
         # chargePower is remembered so our writes don't wipe the app's setting.
         assert coordinator._periodic_power[SERIAL]["charge"] == 5000
 
@@ -145,30 +146,30 @@ class TestProbe:
         mock_api.getTimeChargeBySn.return_value = None
         coordinator = make_coordinator()
 
-        assert await coordinator.async_probe_periodic_support(SERIAL) is False
-        assert coordinator._periodic_support[SERIAL] is False
+        assert await coordinator.async_probe_periodic_readable(SERIAL) is False
+        assert coordinator._periodic_readable[SERIAL] is False
 
     async def test_transport_error_leaves_state_unknown(self, make_coordinator, mock_api):
         mock_api.getTimeChargeBySn.side_effect = OSError("connection reset")
         coordinator = make_coordinator()
 
-        assert await coordinator.async_probe_periodic_support(SERIAL) is None
+        assert await coordinator.async_probe_periodic_readable(SERIAL) is None
         # Nothing cached, so the next write retries rather than giving up.
-        assert SERIAL not in coordinator._periodic_support
+        assert SERIAL not in coordinator._periodic_readable
 
 
 class TestDualWrite:
-    async def test_periodic_written_before_legacy(self, supported, mock_api):
+    async def test_periodic_written_before_legacy(self, readable, mock_api):
         order = []
         mock_api.setTimeChargeBySn = AsyncMock(side_effect=lambda *a, **k: order.append("periodic"))
         mock_api.updateChargeConfigInfo = AsyncMock(side_effect=lambda *a, **k: order.append("legacy"))
 
-        await supported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+        await readable.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
 
         assert order == ["periodic", "legacy"]
 
-    async def test_periodic_payload_is_daily_with_no_weeks(self, supported, mock_api):
-        await supported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+    async def test_periodic_payload_is_daily_with_no_weeks(self, readable, mock_api):
+        await readable.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
 
         args, kwargs = mock_api.setTimeChargeBySn.await_args
         serial, cycle_type, charge_list, discharge_list = args
@@ -179,9 +180,9 @@ class TestDualWrite:
         assert all("weeks" not in period for period in charge_list + discharge_list)
         assert kwargs == {"gridChargeCycle": 1, "ctrDisCycle": 1}
 
-    async def test_both_lists_always_sent(self, supported, mock_api):
+    async def test_both_lists_always_sent(self, readable, mock_api):
         """A charge-only edit must still carry the current discharge periods."""
-        await supported.async_write_charge_config(SERIAL, bat_high_cap=80)
+        await readable.async_write_charge_config(SERIAL, bat_high_cap=80)
 
         _, _, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
         assert charge_list and discharge_list
@@ -192,7 +193,7 @@ class TestDualWrite:
             charge_timeChaf1="00:00", charge_timeChae1="00:00",
             discharge_timeDisf1="00:00", discharge_timeDise1="00:00",
         )}
-        coordinator._periodic_support[SERIAL] = True
+        coordinator._periodic_readable[SERIAL] = True
 
         await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
 
@@ -200,16 +201,16 @@ class TestDualWrite:
         assert charge_list == []
         assert discharge_list == []
 
-    async def test_legacy_argument_order_unchanged(self, supported, mock_api):
+    async def test_legacy_argument_order_unchanged(self, readable, mock_api):
         """The legacy call must keep passing end times before start times."""
-        await supported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+        await readable.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
 
         args = mock_api.updateChargeConfigInfo.await_args.args
         # (serial, batHighCap, gridCharge, timeChae1, timeChae2, timeChaf1, timeChaf2)
         assert args == (SERIAL, 90, 1, "05:00", "00:00", "02:00", "00:00")
 
-    async def test_discharge_legacy_argument_order_unchanged(self, supported, mock_api):
-        await supported.async_write_discharge_config(SERIAL, ctr_dis=0)
+    async def test_discharge_legacy_argument_order_unchanged(self, readable, mock_api):
+        await readable.async_write_discharge_config(SERIAL, ctr_dis=0)
 
         args = mock_api.updateDisChargeConfigInfo.await_args.args
         # (serial, batUseCap, ctrDis, timeDise1, timeDise2, timeDisf1, timeDisf2)
@@ -222,7 +223,7 @@ class TestDualWrite:
             gridCharge=None, ctrDis=None,
             **{AlphaESSNames.batHighCap: None, AlphaESSNames.batUseCap: None},
         )}
-        coordinator._periodic_support[SERIAL] = True
+        coordinator._periodic_readable[SERIAL] = True
 
         await coordinator.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
 
@@ -231,69 +232,81 @@ class TestDualWrite:
         args = mock_api.updateChargeConfigInfo.await_args.args
         assert args[1:3] == (90, 1)
 
-    async def test_disabled_switch_value_of_zero_is_preserved(self, supported, mock_api):
+    async def test_disabled_switch_value_of_zero_is_preserved(self, readable, mock_api):
         """0 is a valid gridCharge/ctrDis value and must not become the default 1."""
-        await supported.async_write_charge_config(SERIAL, grid_charge=0)
+        await readable.async_write_charge_config(SERIAL, grid_charge=0)
 
         assert mock_api.setTimeChargeBySn.await_args.kwargs["gridChargeCycle"] == 0
         assert mock_api.updateChargeConfigInfo.await_args.args[2] == 0
 
-    async def test_only_the_changed_side_writes_legacy(self, supported, mock_api):
-        await supported.async_write_charge_config(SERIAL, grid_charge=0)
+    async def test_only_the_changed_side_writes_legacy(self, readable, mock_api):
+        await readable.async_write_charge_config(SERIAL, grid_charge=0)
 
         mock_api.updateChargeConfigInfo.assert_awaited_once()
         mock_api.updateDisChargeConfigInfo.assert_not_awaited()
 
 
-class TestUnsupportedSystems:
-    async def test_periodic_skipped_and_legacy_still_written(self, unsupported, mock_api):
-        await unsupported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+class TestWriteIsNeverGated:
+    """The periodic write must not depend on the read endpoint.
 
-        mock_api.setTimeChargeBySn.assert_not_awaited()
+    getTimeChargeBySn is separately permissioned and returns 6017 on exactly
+    the accounts that need the periodic write most, so gating on it would skip
+    the write for the users this is meant to fix (issues #267, #269).
+    """
+
+    async def test_written_even_when_schedule_is_unreadable(self, unreadable, mock_api):
+        await unreadable.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+
+        mock_api.setTimeChargeBySn.assert_awaited_once()
         mock_api.updateChargeConfigInfo.assert_awaited_once()
 
-    async def test_legacy_failure_propagates_when_periodic_unavailable(
-        self, unsupported, mock_api
-    ):
-        """With no periodic write to fall back on, the entity must see the error."""
-        mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
-
-        with pytest.raises(OSError):
-            await unsupported.async_write_charge_config(SERIAL, grid_charge=1)
-
-    async def test_probe_runs_lazily_on_first_write(self, make_coordinator, mock_api):
+    async def test_written_even_when_read_state_is_unknown(self, make_coordinator, mock_api):
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: _schedule_data()}
-        mock_api.getTimeChargeBySn.return_value = None
 
         await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
 
-        mock_api.getTimeChargeBySn.assert_awaited_once_with(SERIAL)
-        mock_api.setTimeChargeBySn.assert_not_awaited()
+        mock_api.setTimeChargeBySn.assert_awaited_once()
         mock_api.updateChargeConfigInfo.assert_awaited_once()
+
+    async def test_write_does_not_trigger_a_read(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
+
+        mock_api.getTimeChargeBySn.assert_not_awaited()
 
 
 class TestFailureHandling:
-    async def test_periodic_failure_propagates(self, supported, mock_api):
-        """Periodic is the primary write, so its failure must reach the entity."""
+    async def test_periodic_failure_falls_through_to_legacy(
+        self, readable, mock_api, caplog
+    ):
+        """A failed periodic write must not abandon the legacy one."""
         mock_api.setTimeChargeBySn.side_effect = OSError("api down")
 
-        with pytest.raises(OSError):
-            await supported.async_write_charge_config(SERIAL, grid_charge=1)
+        await readable.async_write_charge_config(SERIAL, grid_charge=1)
 
-        # The legacy call is never reached, so nothing is half-applied.
-        mock_api.updateChargeConfigInfo.assert_not_awaited()
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+        assert "Periodic schedule write failed" in caplog.text
 
-    async def test_legacy_failure_swallowed_after_periodic_success(
-        self, supported, mock_api, caplog
-    ):
-        """The inverter already has the schedule it acts on — don't fail the write."""
+    async def test_fails_only_when_both_writes_fail(self, readable, mock_api):
+        mock_api.setTimeChargeBySn.side_effect = OSError("api down")
         mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
 
-        await supported.async_write_charge_config(SERIAL, grid_charge=1)
+        with pytest.raises(OSError):
+            await readable.async_write_charge_config(SERIAL, grid_charge=1)
+
+    async def test_legacy_failure_swallowed_after_periodic_success(
+        self, readable, mock_api, caplog
+    ):
+        """The periodic request went through — don't fail the whole write."""
+        mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
+
+        await readable.async_write_charge_config(SERIAL, grid_charge=1)
 
         mock_api.setTimeChargeBySn.assert_awaited_once()
-        assert "periodic schedule was accepted" in caplog.text
+        assert "periodic schedule request went through" in caplog.text
 
     async def test_overlap_skips_periodic_and_falls_back_to_legacy(
         self, make_coordinator, mock_api, caplog
@@ -302,7 +315,7 @@ class TestFailureHandling:
         coordinator.data = {SERIAL: _schedule_data(
             charge_timeChaf1="01:00", charge_timeChae1="18:00",  # overlaps discharge
         )}
-        coordinator._periodic_support[SERIAL] = True
+        coordinator._periodic_readable[SERIAL] = True
 
         await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
 
@@ -310,14 +323,25 @@ class TestFailureHandling:
         mock_api.updateChargeConfigInfo.assert_awaited_once()
         assert "overlaps discharge period" in caplog.text
 
+    async def test_cancellation_during_periodic_write_is_not_swallowed(
+        self, readable, mock_api
+    ):
+        """Shutdown must cancel the write, not fall through to the legacy call."""
+        mock_api.setTimeChargeBySn.side_effect = asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await readable.async_write_charge_config(SERIAL, grid_charge=1)
+
+        mock_api.updateChargeConfigInfo.assert_not_awaited()
+
     async def test_cancellation_during_legacy_write_is_not_swallowed(
-        self, supported, mock_api
+        self, readable, mock_api
     ):
         """Shutdown must cancel the write, not be logged as a legacy failure."""
         mock_api.updateChargeConfigInfo.side_effect = asyncio.CancelledError()
 
         with pytest.raises(asyncio.CancelledError):
-            await supported.async_write_charge_config(SERIAL, grid_charge=1)
+            await readable.async_write_charge_config(SERIAL, grid_charge=1)
 
     async def test_cancellation_during_probe_is_not_swallowed(
         self, make_coordinator, mock_api
@@ -326,7 +350,7 @@ class TestFailureHandling:
         coordinator = make_coordinator()
 
         with pytest.raises(asyncio.CancelledError):
-            await coordinator.async_probe_periodic_support(SERIAL)
+            await coordinator.async_probe_periodic_readable(SERIAL)
 
     async def test_overlap_still_surfaces_legacy_errors(self, make_coordinator, mock_api):
         """Skipping periodic makes legacy primary again, errors included."""
@@ -334,46 +358,46 @@ class TestFailureHandling:
         coordinator.data = {SERIAL: _schedule_data(
             charge_timeChaf1="01:00", charge_timeChae1="18:00",
         )}
-        coordinator._periodic_support[SERIAL] = True
+        coordinator._periodic_readable[SERIAL] = True
         mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
 
         with pytest.raises(OSError):
             await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
 
 
-class TestSchedulingApiDiagnostic:
-    def test_reports_periodic_when_supported(self, supported):
-        assert supported.get_scheduling_api(SERIAL) == SCHEDULING_API_PERIODIC
+class TestPeriodicScheduleReadDiagnostic:
+    def test_reports_periodic_when_supported(self, readable):
+        assert readable.get_periodic_read_state(SERIAL) == PERIODIC_READ_OK
 
-    def test_reports_legacy_when_not_entitled(self, unsupported):
-        assert unsupported.get_scheduling_api(SERIAL) == SCHEDULING_API_LEGACY
+    def test_reports_legacy_when_not_entitled(self, unreadable):
+        assert unreadable.get_periodic_read_state(SERIAL) == PERIODIC_READ_UNAVAILABLE
 
     def test_reports_unknown_before_the_probe_answers(self, make_coordinator):
-        assert make_coordinator().get_scheduling_api(SERIAL) == SCHEDULING_API_UNKNOWN
+        assert make_coordinator().get_periodic_read_state(SERIAL) == PERIODIC_READ_UNKNOWN
 
-    def test_published_into_coordinator_data(self, supported):
-        supported._update_diagnostics()
-        assert supported.data[SERIAL][AlphaESSNames.SchedulingApi] == SCHEDULING_API_PERIODIC
+    def test_published_into_coordinator_data(self, readable):
+        readable._update_diagnostics()
+        assert readable.data[SERIAL][AlphaESSNames.PeriodicScheduleRead] == PERIODIC_READ_OK
 
     async def test_unknown_support_is_retried(self, make_coordinator, mock_api):
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: _schedule_data()}
         mock_api.getTimeChargeBySn.return_value = {"chargeTimeList": [], "dischargeTimeList": []}
 
-        await coordinator._async_resolve_unknown_scheduling_api()
+        await coordinator._async_resolve_unknown_periodic_read()
 
         mock_api.getTimeChargeBySn.assert_awaited_once_with(SERIAL)
-        assert coordinator.get_scheduling_api(SERIAL) == SCHEDULING_API_PERIODIC
+        assert coordinator.get_periodic_read_state(SERIAL) == PERIODIC_READ_OK
 
-    async def test_known_support_is_not_reprobed(self, supported, mock_api):
-        await supported._async_resolve_unknown_scheduling_api()
+    async def test_known_support_is_not_reprobed(self, readable, mock_api):
+        await readable._async_resolve_unknown_periodic_read()
 
         mock_api.getTimeChargeBySn.assert_not_awaited()
 
 
 class TestButtonAndResetPaths:
-    async def test_reset_clears_periodic_schedule(self, supported, mock_api):
-        await supported.reset_config(SERIAL)
+    async def test_reset_clears_periodic_schedule(self, readable, mock_api):
+        await readable.reset_config(SERIAL)
 
         _, cycle_type, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
         assert cycle_type == PERIODIC_DAILY
@@ -383,14 +407,14 @@ class TestButtonAndResetPaths:
         mock_api.updateChargeConfigInfo.assert_awaited_once()
         mock_api.updateDisChargeConfigInfo.assert_awaited_once()
 
-    async def test_update_charge_writes_both_apis(self, supported, mock_api):
-        await supported.update_charge("batHighCap", SERIAL, 60)
+    async def test_update_charge_writes_both_apis(self, readable, mock_api):
+        await readable.update_charge("batHighCap", SERIAL, 60)
 
         mock_api.setTimeChargeBySn.assert_awaited_once()
         mock_api.updateChargeConfigInfo.assert_awaited_once()
 
-    async def test_update_discharge_writes_both_apis(self, supported, mock_api):
-        await supported.update_discharge("batUseCap", SERIAL, 30)
+    async def test_update_discharge_writes_both_apis(self, readable, mock_api):
+        await readable.update_discharge("batUseCap", SERIAL, 30)
 
         mock_api.setTimeChargeBySn.assert_awaited_once()
         mock_api.updateDisChargeConfigInfo.assert_awaited_once()

--- a/tests/test_periodic_schedule.py
+++ b/tests/test_periodic_schedule.py
@@ -1,0 +1,363 @@
+"""Tests for the periodic (setTimeChargeBySn) charge/discharge schedule.
+
+Covers the dual-write behaviour added for issues #267 and #269: every schedule
+change is pushed to the periodic API first (the only one migrated AlphaESS
+backends act on) and then to the legacy two-slot endpoints.
+"""
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.alphaess.coordinator import (
+    PERIODIC_DAILY,
+    find_overlapping_periods,
+)
+from custom_components.alphaess.enums import AlphaESSNames
+
+SERIAL = "ALP123456"
+
+
+def _period(begin, end):
+    return {"beginTime": begin, "endTime": end, "chargeLimit": 90}
+
+
+def _schedule_data(**overrides):
+    """Coordinator data for a system with one charge and one discharge window."""
+    data = {
+        "gridCharge": 1,
+        AlphaESSNames.batHighCap: 90,
+        "charge_timeChaf1": "01:00",
+        "charge_timeChae1": "05:00",
+        "charge_timeChaf2": "00:00",
+        "charge_timeChae2": "00:00",
+        "ctrDis": 1,
+        AlphaESSNames.batUseCap: 20,
+        "discharge_timeDisf1": "17:00",
+        "discharge_timeDise1": "21:00",
+        "discharge_timeDisf2": "00:00",
+        "discharge_timeDise2": "00:00",
+    }
+    data.update(overrides)
+    return data
+
+
+@pytest.fixture
+def supported(make_coordinator, mock_api):
+    """A coordinator whose system is entitled to the periodic API."""
+    coordinator = make_coordinator()
+    coordinator.data = {SERIAL: _schedule_data()}
+    coordinator._periodic_support[SERIAL] = True
+    return coordinator
+
+
+@pytest.fixture
+def unsupported(make_coordinator, mock_api):
+    """A coordinator whose system returned 6017 (feature not entitled)."""
+    coordinator = make_coordinator()
+    coordinator.data = {SERIAL: _schedule_data()}
+    coordinator._periodic_support[SERIAL] = False
+    return coordinator
+
+
+class TestOverlapDetection:
+    def test_no_overlap(self):
+        assert find_overlapping_periods([_period("01:00", "05:00")],
+                                        [_period("17:00", "21:00")]) is None
+
+    def test_touching_edges_do_not_overlap(self):
+        assert find_overlapping_periods([_period("01:00", "05:00")],
+                                        [_period("05:00", "07:00")]) is None
+
+    def test_plain_overlap(self):
+        assert find_overlapping_periods([_period("01:00", "06:00")],
+                                        [_period("05:00", "07:00")]) is not None
+
+    def test_overnight_charge_overlaps_early_discharge(self):
+        # 23:00-02:00 wraps midnight and must still be caught.
+        assert find_overlapping_periods([_period("23:00", "02:00")],
+                                        [_period("01:00", "03:00")]) is not None
+
+    def test_overnight_without_overlap(self):
+        assert find_overlapping_periods([_period("23:00", "02:00")],
+                                        [_period("10:00", "12:00")]) is None
+
+    def test_empty_lists(self):
+        assert find_overlapping_periods([], []) is None
+
+
+class TestBuildPeriodList:
+    def test_drops_disabled_slots(self, supported):
+        periods = supported._build_period_list(
+            [("01:00", "05:00"), ("00:00", "00:00")], 90,
+        )
+        assert periods == [{"beginTime": "01:00", "endTime": "05:00", "chargeLimit": 90}]
+
+    def test_all_disabled_gives_empty_list(self, supported):
+        periods = supported._build_period_list(
+            [("00:00", "00:00"), ("12:00", "12:00")], 90,
+        )
+        assert periods == []
+
+    def test_missing_times_are_skipped(self, supported):
+        assert supported._build_period_list([(None, "05:00"), ("01:00", None)], 90) == []
+
+    def test_charge_limit_clamped_to_minimum(self, supported):
+        # The number entity allows 0-100 but the periodic API rejects <10 (6001).
+        periods = supported._build_period_list([("17:00", "21:00")], 5)
+        assert periods[0]["chargeLimit"] == 10
+
+    def test_charge_limit_clamped_to_maximum(self, supported):
+        periods = supported._build_period_list([("01:00", "05:00")], 150)
+        assert periods[0]["chargeLimit"] == 100
+
+    def test_invalid_charge_limit_falls_back_to_minimum(self, supported):
+        periods = supported._build_period_list([("01:00", "05:00")], None)
+        assert periods[0]["chargeLimit"] == 10
+
+    def test_charge_power_included_when_known(self, supported):
+        periods = supported._build_period_list([("01:00", "05:00")], 90, 5000)
+        assert periods[0]["chargePower"] == 5000
+
+    def test_charge_power_omitted_when_unknown(self, supported):
+        periods = supported._build_period_list([("01:00", "05:00")], 90)
+        assert "chargePower" not in periods[0]
+
+
+class TestProbe:
+    async def test_payload_marks_supported(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        mock_api.getTimeChargeBySn.return_value = {
+            "chargeTimeList": [{"beginTime": "01:00", "chargePower": 5000}],
+            "dischargeTimeList": [],
+        }
+
+        assert await coordinator.async_probe_periodic_support(SERIAL) is True
+        assert coordinator._periodic_support[SERIAL] is True
+        # chargePower is remembered so our writes don't wipe the app's setting.
+        assert coordinator._periodic_power[SERIAL]["charge"] == 5000
+
+    async def test_none_marks_unsupported(self, make_coordinator, mock_api):
+        # The library returns None for 6017 "no operation permissions".
+        mock_api.getTimeChargeBySn.return_value = None
+        coordinator = make_coordinator()
+
+        assert await coordinator.async_probe_periodic_support(SERIAL) is False
+        assert coordinator._periodic_support[SERIAL] is False
+
+    async def test_transport_error_leaves_state_unknown(self, make_coordinator, mock_api):
+        mock_api.getTimeChargeBySn.side_effect = OSError("connection reset")
+        coordinator = make_coordinator()
+
+        assert await coordinator.async_probe_periodic_support(SERIAL) is None
+        # Nothing cached, so the next write retries rather than giving up.
+        assert SERIAL not in coordinator._periodic_support
+
+
+class TestDualWrite:
+    async def test_periodic_written_before_legacy(self, supported, mock_api):
+        order = []
+        mock_api.setTimeChargeBySn = AsyncMock(side_effect=lambda *a, **k: order.append("periodic"))
+        mock_api.updateChargeConfigInfo = AsyncMock(side_effect=lambda *a, **k: order.append("legacy"))
+
+        await supported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+
+        assert order == ["periodic", "legacy"]
+
+    async def test_periodic_payload_is_daily_with_no_weeks(self, supported, mock_api):
+        await supported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+
+        args, kwargs = mock_api.setTimeChargeBySn.await_args
+        serial, cycle_type, charge_list, discharge_list = args
+        assert serial == SERIAL
+        assert cycle_type == PERIODIC_DAILY == 0
+        assert charge_list == [{"beginTime": "02:00", "endTime": "05:00", "chargeLimit": 90}]
+        assert discharge_list == [{"beginTime": "17:00", "endTime": "21:00", "chargeLimit": 20}]
+        assert all("weeks" not in period for period in charge_list + discharge_list)
+        assert kwargs == {"gridChargeCycle": 1, "ctrDisCycle": 1}
+
+    async def test_both_lists_always_sent(self, supported, mock_api):
+        """A charge-only edit must still carry the current discharge periods."""
+        await supported.async_write_charge_config(SERIAL, bat_high_cap=80)
+
+        _, _, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
+        assert charge_list and discharge_list
+
+    async def test_empty_lists_sent_not_null(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data(
+            charge_timeChaf1="00:00", charge_timeChae1="00:00",
+            discharge_timeDisf1="00:00", discharge_timeDise1="00:00",
+        )}
+        coordinator._periodic_support[SERIAL] = True
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
+
+        _, _, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
+        assert charge_list == []
+        assert discharge_list == []
+
+    async def test_legacy_argument_order_unchanged(self, supported, mock_api):
+        """The legacy call must keep passing end times before start times."""
+        await supported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+
+        args = mock_api.updateChargeConfigInfo.await_args.args
+        # (serial, batHighCap, gridCharge, timeChae1, timeChae2, timeChaf1, timeChaf2)
+        assert args == (SERIAL, 90, 1, "05:00", "00:00", "02:00", "00:00")
+
+    async def test_discharge_legacy_argument_order_unchanged(self, supported, mock_api):
+        await supported.async_write_discharge_config(SERIAL, ctr_dis=0)
+
+        args = mock_api.updateDisChargeConfigInfo.await_args.args
+        # (serial, batUseCap, ctrDis, timeDise1, timeDise2, timeDisf1, timeDisf2)
+        assert args == (SERIAL, 20, 0, "21:00", "00:00", "17:00", "00:00")
+
+    async def test_null_config_values_fall_back_to_defaults(self, make_coordinator, mock_api):
+        """The parsers store None when the API omits a field; don't send that on."""
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data(
+            gridCharge=None, ctrDis=None,
+            **{AlphaESSNames.batHighCap: None, AlphaESSNames.batUseCap: None},
+        )}
+        coordinator._periodic_support[SERIAL] = True
+
+        await coordinator.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+
+        kwargs = mock_api.setTimeChargeBySn.await_args.kwargs
+        assert kwargs == {"gridChargeCycle": 1, "ctrDisCycle": 1}
+        args = mock_api.updateChargeConfigInfo.await_args.args
+        assert args[1:3] == (90, 1)
+
+    async def test_disabled_switch_value_of_zero_is_preserved(self, supported, mock_api):
+        """0 is a valid gridCharge/ctrDis value and must not become the default 1."""
+        await supported.async_write_charge_config(SERIAL, grid_charge=0)
+
+        assert mock_api.setTimeChargeBySn.await_args.kwargs["gridChargeCycle"] == 0
+        assert mock_api.updateChargeConfigInfo.await_args.args[2] == 0
+
+    async def test_only_the_changed_side_writes_legacy(self, supported, mock_api):
+        await supported.async_write_charge_config(SERIAL, grid_charge=0)
+
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+        mock_api.updateDisChargeConfigInfo.assert_not_awaited()
+
+
+class TestUnsupportedSystems:
+    async def test_periodic_skipped_and_legacy_still_written(self, unsupported, mock_api):
+        await unsupported.async_write_charge_config(SERIAL, times={"timeChaf1": "02:00"})
+
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+
+    async def test_legacy_failure_propagates_when_periodic_unavailable(
+        self, unsupported, mock_api
+    ):
+        """With no periodic write to fall back on, the entity must see the error."""
+        mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
+
+        with pytest.raises(OSError):
+            await unsupported.async_write_charge_config(SERIAL, grid_charge=1)
+
+    async def test_probe_runs_lazily_on_first_write(self, make_coordinator, mock_api):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data()}
+        mock_api.getTimeChargeBySn.return_value = None
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
+
+        mock_api.getTimeChargeBySn.assert_awaited_once_with(SERIAL)
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+
+
+class TestFailureHandling:
+    async def test_periodic_failure_propagates(self, supported, mock_api):
+        """Periodic is the primary write, so its failure must reach the entity."""
+        mock_api.setTimeChargeBySn.side_effect = OSError("api down")
+
+        with pytest.raises(OSError):
+            await supported.async_write_charge_config(SERIAL, grid_charge=1)
+
+        # The legacy call is never reached, so nothing is half-applied.
+        mock_api.updateChargeConfigInfo.assert_not_awaited()
+
+    async def test_legacy_failure_swallowed_after_periodic_success(
+        self, supported, mock_api, caplog
+    ):
+        """The inverter already has the schedule it acts on — don't fail the write."""
+        mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
+
+        await supported.async_write_charge_config(SERIAL, grid_charge=1)
+
+        mock_api.setTimeChargeBySn.assert_awaited_once()
+        assert "periodic schedule was accepted" in caplog.text
+
+    async def test_overlap_skips_periodic_and_falls_back_to_legacy(
+        self, make_coordinator, mock_api, caplog
+    ):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data(
+            charge_timeChaf1="01:00", charge_timeChae1="18:00",  # overlaps discharge
+        )}
+        coordinator._periodic_support[SERIAL] = True
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
+
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+        assert "overlaps discharge period" in caplog.text
+
+    async def test_cancellation_during_legacy_write_is_not_swallowed(
+        self, supported, mock_api
+    ):
+        """Shutdown must cancel the write, not be logged as a legacy failure."""
+        mock_api.updateChargeConfigInfo.side_effect = asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await supported.async_write_charge_config(SERIAL, grid_charge=1)
+
+    async def test_cancellation_during_probe_is_not_swallowed(
+        self, make_coordinator, mock_api
+    ):
+        mock_api.getTimeChargeBySn.side_effect = asyncio.CancelledError()
+        coordinator = make_coordinator()
+
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator.async_probe_periodic_support(SERIAL)
+
+    async def test_overlap_still_surfaces_legacy_errors(self, make_coordinator, mock_api):
+        """Skipping periodic makes legacy primary again, errors included."""
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data(
+            charge_timeChaf1="01:00", charge_timeChae1="18:00",
+        )}
+        coordinator._periodic_support[SERIAL] = True
+        mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
+
+        with pytest.raises(OSError):
+            await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
+
+
+class TestButtonAndResetPaths:
+    async def test_reset_clears_periodic_schedule(self, supported, mock_api):
+        await supported.reset_config(SERIAL)
+
+        _, cycle_type, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
+        assert cycle_type == PERIODIC_DAILY
+        # Everything reset to 00:00 means no periods at all.
+        assert charge_list == []
+        assert discharge_list == []
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+        mock_api.updateDisChargeConfigInfo.assert_awaited_once()
+
+    async def test_update_charge_writes_both_apis(self, supported, mock_api):
+        await supported.update_charge("batHighCap", SERIAL, 60)
+
+        mock_api.setTimeChargeBySn.assert_awaited_once()
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+
+    async def test_update_discharge_writes_both_apis(self, supported, mock_api):
+        await supported.update_discharge("batUseCap", SERIAL, 30)
+
+        mock_api.setTimeChargeBySn.assert_awaited_once()
+        mock_api.updateDisChargeConfigInfo.assert_awaited_once()

--- a/tests/test_periodic_schedule.py
+++ b/tests/test_periodic_schedule.py
@@ -187,19 +187,35 @@ class TestDualWrite:
         _, _, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
         assert charge_list and discharge_list
 
-    async def test_empty_lists_sent_not_null(self, make_coordinator, mock_api):
+    async def test_skipped_when_a_list_would_be_empty(
+        self, make_coordinator, mock_api, caplog
+    ):
+        """The live API rejects an empty list with 6001 "time list is null"."""
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: _schedule_data(
-            charge_timeChaf1="00:00", charge_timeChae1="00:00",
             discharge_timeDisf1="00:00", discharge_timeDise1="00:00",
         )}
         coordinator._periodic_readable[SERIAL] = True
 
         await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
 
-        _, _, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
-        assert charge_list == []
-        assert discharge_list == []
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+        mock_api.updateChargeConfigInfo.assert_awaited_once()
+        assert "the discharge list is empty" in caplog.text
+
+    async def test_skipped_when_charge_list_would_be_empty(
+        self, make_coordinator, mock_api, caplog
+    ):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _schedule_data(
+            charge_timeChaf1="00:00", charge_timeChae1="00:00",
+        )}
+        coordinator._periodic_readable[SERIAL] = True
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
+
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+        assert "the charge list is empty" in caplog.text
 
     async def test_legacy_argument_order_unchanged(self, readable, mock_api):
         """The legacy call must keep passing end times before start times."""
@@ -396,14 +412,16 @@ class TestPeriodicScheduleReadDiagnostic:
 
 
 class TestButtonAndResetPaths:
-    async def test_reset_clears_periodic_schedule(self, readable, mock_api):
+    async def test_reset_cannot_clear_the_periodic_schedule(self, readable, mock_api):
+        """Reset zeroes every slot, which leaves no periods to send.
+
+        setTimeChargeBySn has no representation for "no periods", so a reset
+        only reaches the legacy endpoints. Clearing a periodic schedule has to
+        be done from the AlphaESS app.
+        """
         await readable.reset_config(SERIAL)
 
-        _, cycle_type, charge_list, discharge_list = mock_api.setTimeChargeBySn.await_args.args
-        assert cycle_type == PERIODIC_DAILY
-        # Everything reset to 00:00 means no periods at all.
-        assert charge_list == []
-        assert discharge_list == []
+        mock_api.setTimeChargeBySn.assert_not_awaited()
         mock_api.updateChargeConfigInfo.assert_awaited_once()
         mock_api.updateDisChargeConfigInfo.assert_awaited_once()
 

--- a/tests/test_platform_entities.py
+++ b/tests/test_platform_entities.py
@@ -290,6 +290,7 @@ class TestSwitchEntity:
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: {}}
         switch = self._make(coordinator)
+        switch.async_write_ha_state = MagicMock()
         switch._coordinator_key = "unknown"
         await switch._set_value(1)
         mock_api.updateChargeConfigInfo.assert_not_awaited()

--- a/tests/test_platform_entities.py
+++ b/tests/test_platform_entities.py
@@ -438,6 +438,23 @@ class TestTimeEntity:
         assert args == (SERIAL, 12, 0, "00:00", "22:00", "00:00", "20:00")
 
     async def test_set_value_failure_reverts(self, make_coordinator, mock_api):
+        """Only revert when nothing was written — both APIs have to fail."""
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: {"charge_timeChaf1": "03:00"}}
+        entity = self._make(coordinator, "charge_timeChaf1")
+        entity.async_write_ha_state = MagicMock()
+        entity._attr_native_value = dt_time(3, 0)
+        mock_api.setTimeChargeBySn.side_effect = OSError("api down")
+        mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
+
+        await entity.async_set_value(dt_time(8, 0))
+        assert entity._attr_native_value == dt_time(3, 0)
+        coordinator.async_request_refresh.assert_not_awaited()
+
+    async def test_set_value_keeps_value_when_only_legacy_fails(
+        self, make_coordinator, mock_api
+    ):
+        """The periodic request went through, so the change may have landed."""
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: {"charge_timeChaf1": "03:00"}}
         entity = self._make(coordinator, "charge_timeChaf1")
@@ -446,8 +463,8 @@ class TestTimeEntity:
         mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
 
         await entity.async_set_value(dt_time(8, 0))
-        assert entity._attr_native_value == dt_time(3, 0)
-        coordinator.async_request_refresh.assert_not_awaited()
+        assert entity._attr_native_value == dt_time(8, 0)
+        coordinator.async_request_refresh.assert_awaited_once()
 
     def test_available_and_properties(self, make_coordinator):
         coordinator = make_coordinator()

--- a/tests/test_platform_entities.py
+++ b/tests/test_platform_entities.py
@@ -456,14 +456,20 @@ class TestTimeEntity:
     ):
         """The periodic request went through, so the change may have landed."""
         coordinator = make_coordinator()
-        coordinator.data = {SERIAL: {"charge_timeChaf1": "03:00"}}
+        # Both sides need a period, otherwise the periodic write is skipped.
+        coordinator.data = {SERIAL: {
+            "charge_timeChaf1": "03:00", "charge_timeChae1": "05:00",
+            "discharge_timeDisf1": "17:00", "discharge_timeDise1": "21:00",
+        }}
         entity = self._make(coordinator, "charge_timeChaf1")
         entity.async_write_ha_state = MagicMock()
         entity._attr_native_value = dt_time(3, 0)
         mock_api.updateChargeConfigInfo.side_effect = OSError("api down")
 
-        await entity.async_set_value(dt_time(8, 0))
-        assert entity._attr_native_value == dt_time(8, 0)
+        # 04:00 keeps the charge window inside 03:00-05:00, clear of the
+        # discharge window, so the periodic write actually goes out.
+        await entity.async_set_value(dt_time(4, 0))
+        assert entity._attr_native_value == dt_time(4, 0)
         coordinator.async_request_refresh.assert_awaited_once()
 
     def test_available_and_properties(self, make_coordinator):


### PR DESCRIPTION
Some regions have moved to a backend that only acts on setTimeChargeBySn. There the legacy updateChargeConfigInfo call still returns 200 but the inverter never applies it until you press Save in the app, or SetConfig times out. Other regions still only understand the legacy endpoints, so write both: periodic first, legacy after.

Support is probed once per inverter on setup; systems that aren't entitled return 6017 and keep using the legacy endpoints only.

The write payload was being rebuilt in time.py, switch.py and number.py, so move it onto the coordinator and have the buttons and services use it too.

Fixes #267
Fixes #269