### PR TITLE
Stop posting the write-only enable flags back at the inverter

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,10 @@ What this setup depends on:
 - **Each Apply is one full transaction** (fresh read, then one write), and moving
   a window costs two because Predbat disables the charge flag first. Weigh that
   against the request limits described below.
-- **A self-consumption working mode locks everything above**, so Predbat's writes
-  fail until the mode is changed in the AlphaESS app.
+- **A non-timed working mode, or both timers switched off, locks everything
+  above**, so Predbat's writes fail until a timer is enabled again — from the
+  Scheduled Charging/Discharging switches, or in the AlphaESS app if the
+  inverter is genuinely in a self-consumption mode.
 
 If you drive the services from Predbat instead, note two things about its
 service templates: falsy values are dropped before the call, so `enabled: false`
@@ -277,20 +279,31 @@ mode such as **Self Consumption (Plus)** — live probing showed those modes
 flip both enable flags to `0` while keeping the configured windows stored —
 and is unavailable while no schedule store is readable.
 
-While a self-consumption mode is active, **everything time-based locks**:
-the time entities, cutoff SOC and power numbers, the enable switches, the
-duration buttons, Reset, Apply/Discard, and the
-`setbatterycharge`/`setbatterydischarge` services are all unavailable or
-refused with a message naming the remedy. Field testing showed the working
-mode is app-authority only — writing an enable flag through the OpenAPI does
-not leave a self-consumption mode, so offering the switches would only write
-flags the inverter ignores and corrupt the mode indicator. Change the
-working mode in the AlphaESS app; the integration notices on the next poll
-and unlocks everything automatically. For the same reason, HA refuses to
-turn off the *last* enabled timer: the resulting flag state is
-indistinguishable from a self-consumption mode, so disabling the final timer
-also belongs in the app. A draft stranded by an app-side mode change is kept
-and becomes applicable again once a time-based mode is active.
+Both enable flags reading `0` has two possible meanings and the OpenAPI
+offers no way to tell them apart: a non-timed working mode such as **Self
+Consumption (Plus)** is running, or both timers are simply switched off. In
+either case **everything time-based locks**: the time entities, cutoff SOC and
+power numbers, the duration buttons, Reset, Apply/Discard, and any
+`setbatterycharge`/`setbatterydischarge` call carrying a window, cutoff or
+power are unavailable or refused with a message naming the remedy.
+
+**The two enable switches are the exception.** *Scheduled Charging* and
+*Scheduled Discharging* stay available so a timer can always be switched back
+on from Home Assistant, and that write goes out immediately rather than
+becoming a draft — Apply is unavailable in this state, so a staged change could
+never be sent. Raising a flag is the one write that is safe under either
+reading: field testing showed a self-consumption inverter ignores it, and the
+next poll simply locks the controls again. Everything unlocks by itself once a
+flag reads `1`. Turning a switch *off* here is still refused, because both are
+already off and the only reading under which it would mean something is the one
+the API cannot confirm.
+
+Changing the working mode itself remains app-authority only: writing an enable
+flag does not leave a self-consumption mode. For the same reason HA refuses to
+turn off the *last* enabled timer — the resulting `0/0` state is exactly the
+ambiguous one above, so disabling the final timer belongs in the AlphaESS app.
+A draft stranded by an app-side mode change is kept and becomes applicable
+again once a timed mode is active.
 
 The diagnostic sensor `Periodic Schedule Read` reports:
 

--- a/README.md
+++ b/README.md
@@ -245,10 +245,12 @@ What this setup depends on:
 - **Each Apply is one full transaction** (fresh read, then one write), and moving
   a window costs two because Predbat disables the charge flag first. Weigh that
   against the request limits described below.
-- **A non-timed working mode, or both timers switched off, locks everything
-  above**, so Predbat's writes fail until a timer is enabled again — from the
-  Scheduled Charging/Discharging switches, or in the AlphaESS app if the
-  inverter is genuinely in a self-consumption mode.
+- **Set both enable switches once before letting Predbat write.** The periodic
+  API cannot report whether scheduled charging and discharging are on, so until
+  Scheduled Charging and Scheduled Discharging have an answer every write is
+  refused — see *The enable flags are write-only* below. Recording both as off
+  additionally locks the time-based controls, since that is how the API is told
+  to run self-consumption.
 
 If you drive the services from Predbat instead, note two things about its
 service templates: falsy values are dropped before the call, so `enabled: false`
@@ -279,31 +281,46 @@ mode such as **Self Consumption (Plus)** — live probing showed those modes
 flip both enable flags to `0` while keeping the configured windows stored —
 and is unavailable while no schedule store is readable.
 
-Both enable flags reading `0` has two possible meanings and the OpenAPI
-offers no way to tell them apart: a non-timed working mode such as **Self
-Consumption (Plus)** is running, or both timers are simply switched off. In
-either case **everything time-based locks**: the time entities, cutoff SOC and
-power numbers, the duration buttons, Reset, Apply/Discard, and any
-`setbatterycharge`/`setbatterydischarge` call carrying a window, cutoff or
-power are unavailable or refused with a message naming the remedy.
+### The enable flags are write-only
 
-**The two enable switches are the exception.** *Scheduled Charging* and
-*Scheduled Discharging* stay available so a timer can always be switched back
-on from Home Assistant, and that write goes out immediately rather than
-becoming a draft — Apply is unavailable in this state, so a staged change could
-never be sent. Raising a flag is the one write that is safe under either
-reading: field testing showed a self-consumption inverter ignores it, and the
-next poll simply locks the controls again. Everything unlocks by itself once a
-flag reads `1`. Turning a switch *off* here is still refused, because both are
-already off and the only reading under which it would mean something is the one
-the API cannot confirm.
+`gridChargeCycle` and `ctrDisCycle` decide whether scheduled charging and
+discharging run. On the periodic store they are **write-only**: probing on
+issue #267 showed `getTimeChargeBySn` answers `0` for both however the inverter
+is actually set, while `setTimeChargeBySn` acts on what it is sent.
 
-Changing the working mode itself remains app-authority only: writing an enable
-flag does not leave a self-consumption mode. For the same reason HA refuses to
-turn off the *last* enabled timer — the resulting `0/0` state is exactly the
-ambiguous one above, so disabling the final timer belongs in the AlphaESS app.
-A draft stranded by an app-side mode change is kept and becomes applicable
-again once a timed mode is active.
+| sent | effect on the inverter |
+| --- | --- |
+| `1 / 0` | schedule active, scheduled discharging off |
+| `1 / 1` | both schedules enabled |
+| `0 / 1` | scheduled discharging only |
+| `0 / 0` | **switches the inverter to self-consumption** |
+
+Two consequences follow, and the integration is built around them.
+
+**The read is never echoed back.** A replacement built from the read would post
+`0/0` on every write and quietly switch the inverter out of timed control.
+Snapshots therefore drop both flags, and every write sends a value that came
+from the user instead.
+
+**The switches are the record.** *Scheduled Charging* and *Scheduled
+Discharging* are the only place that answer can live, so their published state
+is restored across restarts and handed back to the coordinator. Until both have
+an answer they read **unknown**, and a schedule write is refused with a message
+naming them rather than guessing which working mode you wanted. Editing and
+staging still work; only the write needs the answer.
+
+Once both are recorded, a request to set them to `0/0` is a real one — it is how
+the API is told to run self-consumption — so it locks the time-based controls:
+time entities, cutoff SOC and power numbers, duration buttons, Reset,
+Apply/Discard, and any service call carrying a window, cutoff or power. The two
+switches stay available so the inverter can be brought back to a timed mode from
+Home Assistant, and turning one on there is sent immediately rather than staged,
+since Apply is unavailable in that state. Home Assistant still refuses to author
+`0/0` by turning off the *last* enabled timer from a service.
+
+In legacy backup mode `gridCharge` and `ctrDis` are ordinary read-write fields
+and none of the above applies: they are read from the store, reported as-is, and
+a mode change made in the AlphaESS app is picked up on the next poll.
 
 The diagnostic sensor `Periodic Schedule Read` reports:
 

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -61,6 +61,21 @@ PERIODIC_NOT_ENTITLED = 6017
 PERIODIC_OVERLAP = 6008
 
 
+def _is_enable_only(
+    flag: int | None,
+    limit: float | None,
+    times: dict[str, str] | None,
+    powers: dict[str, float] | None,
+) -> bool:
+    """Return whether a write does nothing but switch a timer on.
+
+    The one change permitted while no timed control is reported: it cannot
+    move a window, a cutoff or a power, so it is safe to send against a store
+    whose working mode cannot be read.
+    """
+    return flag == 1 and not limit and not times and not powers
+
+
 class ScheduleWriteError(HomeAssistantError):
     """Raised when a full-replacement schedule cannot be applied safely."""
 
@@ -1240,15 +1255,17 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             )
         active = self.is_time_based_control_active(serial)
         if active is False:
-            # A self-consumption working mode is running. Field testing
-            # showed the enable flags are accepted but ignored there, so
-            # nothing — switches included — may be edited; the mode can only
-            # be changed in the AlphaESS app.
+            # Either a self-consumption working mode is running or both
+            # timers are simply switched off, and the OpenAPI cannot tell
+            # those apart. Nothing may be staged for a store in that state;
+            # switching a timer back on is an immediate action instead, since
+            # Apply is unavailable here too.
             raise ScheduleWriteError(
-                "Time-based control is disabled: the inverter is in a "
-                "self-consumption working mode, which can only be changed in "
-                "the AlphaESS app. Controls unlock automatically once a "
-                "time-based mode is active"
+                "Time-based control is disabled: the inverter reports no timed "
+                "control, either because a self-consumption working mode is "
+                "running or because both timers are switched off. Turn "
+                "Scheduled Charging or Scheduled Discharging on to re-enable a "
+                "timer; a working mode can only be changed in the AlphaESS app"
             )
         if active is True:
             # Refuse to author the 0/0 flag state: it is indistinguishable
@@ -1379,6 +1396,22 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             and self.is_time_based_control_active(serial) is not False
         )
 
+    def can_unlock_time_controls(self, serial: str) -> bool:
+        """Return whether a timer can still be switched back on from here.
+
+        Both enable flags reading 0 means either a self-consumption working
+        mode or simply that both timers are off, and the OpenAPI cannot tell
+        those apart. Locking everything on that reading left the second case
+        with no way out: the switches that would turn a timer back on were
+        part of what locked. Raising a flag is the one write that is safe
+        either way - a self-consumption inverter ignores it and the next poll
+        locks again - so it stays available while everything else does not.
+        """
+        return (
+            self.can_stage_schedule(serial)
+            and self.is_time_based_control_active(serial) is False
+        )
+
     def can_reset_schedule(self, serial: str) -> bool:
         """Return whether Reset Charge/Discharge can possibly succeed.
 
@@ -1487,11 +1520,13 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         timeChaf2/timeChae2); anything omitted keeps its current value.
         """
         active = self.is_time_based_control_active(serial)
-        if active is False:
+        if active is False and not _is_enable_only(grid_charge, bat_high_cap, times, powers):
             raise ScheduleWriteError(
                 "Time-based control is disabled: the inverter is in a "
-                "self-consumption working mode, which can only be changed in "
-                "the AlphaESS app; nothing was written"
+                "self-consumption working mode, or both timers are switched "
+                "off. Only switching a timer back on can be written from here; "
+                "the working mode itself can only be changed in the AlphaESS "
+                "app. Nothing was written"
             )
         if grid_charge == 0 and active is True:
             flags = self._committed_enable_flags(serial)
@@ -1523,11 +1558,13 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         timeDisf2/timeDise2); anything omitted keeps its current value.
         """
         active = self.is_time_based_control_active(serial)
-        if active is False:
+        if active is False and not _is_enable_only(ctr_dis, bat_use_cap, times, powers):
             raise ScheduleWriteError(
                 "Time-based control is disabled: the inverter is in a "
-                "self-consumption working mode, which can only be changed in "
-                "the AlphaESS app; nothing was written"
+                "self-consumption working mode, or both timers are switched "
+                "off. Only switching a timer back on can be written from here; "
+                "the working mode itself can only be changed in the AlphaESS "
+                "app. Nothing was written"
             )
         if ctr_dis == 0 and active is True:
             flags = self._committed_enable_flags(serial)

--- a/custom_components/alphaess/coordinator.py
+++ b/custom_components/alphaess/coordinator.py
@@ -510,6 +510,15 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         # Missing = not yet determined, True/False = known answer.
         self._periodic_readable: dict[str, bool] = {}
 
+        # gridChargeCycle/ctrDisCycle are write-only. getTimeChargeBySn answers
+        # 0 for both whatever the inverter is doing, while setTimeChargeBySn
+        # acts on them: 0/0 switches the inverter to self-consumption (probed
+        # on #267). So the read cannot be echoed back, and the only record of
+        # what was asked for is the one kept here — fed by the two switches and
+        # confirmed by each successful write.
+        self._periodic_enable_intent: dict[str, dict[str, int]] = {}
+        self._periodic_enable_sent: dict[str, dict[str, int]] = {}
+
         # Entity changes are drafts. A user can edit start/end/limits/switches
         # without emitting a series of unsafe intermediate full replacements,
         # then commit once with the Apply Schedule button.
@@ -679,6 +688,8 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 self._schedule_draft_base_legacy,
                 self._schedule_draft_revisions,
                 self._schedule_write_revisions,
+                self._periodic_enable_intent,
+                self._periodic_enable_sent,
                 self.number_settings,
                 self._inverter_error_count,
                 self.last_charge_update,
@@ -1040,12 +1051,13 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         if payload.get("executeCycleType") not in (0, 1):
             raise ScheduleWriteError("The periodic schedule omitted a valid executeCycleType")
 
+        # gridChargeCycle/ctrDisCycle are deliberately dropped: the endpoint
+        # answers 0 for both regardless of the inverter's actual mode, so
+        # keeping them would mean echoing 0/0 back on the next write and
+        # switching the inverter to self-consumption. See _resolve_periodic_enable.
         result: dict[str, Any] = {
             "executeCycleType": int(payload["executeCycleType"]),
         }
-        for key in ("gridChargeCycle", "ctrDisCycle"):
-            if payload.get(key) is not None:
-                result[key] = int(payload[key])
 
         writable_fields = (
             "beginTime", "endTime", "weeks", "chargePower", "chargeLimit",
@@ -1084,7 +1096,9 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                     charge_periods[0].get("chargeLimit") if charge_periods
                     else self.get_number_setting(serial, "batHighCap", 90)
                 ),
-                "gridCharge": schedule.get("gridChargeCycle", 1),
+                "gridCharge": (self._periodic_enable_intent.get(serial) or {}).get(
+                    "gridChargeCycle"
+                ),
                 "timeChaf1": "00:00", "timeChae1": "00:00",
                 "timeChaf2": "00:00", "timeChae2": "00:00",
                 "chargePower1": None, "chargePower2": None,
@@ -1097,7 +1111,9 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                     discharge_periods[0].get("chargeLimit") if discharge_periods
                     else self.get_number_setting(serial, "batUseCap", 10)
                 ),
-                "ctrDis": schedule.get("ctrDisCycle", 1),
+                "ctrDis": (self._periodic_enable_intent.get(serial) or {}).get(
+                    "ctrDisCycle"
+                ),
                 "timeDisf1": "00:00", "timeDise1": "00:00",
                 "timeDisf2": "00:00", "timeDise2": "00:00",
                 "chargePower1": None, "chargePower2": None,
@@ -1189,8 +1205,11 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         # Whether any time-based control is enabled in the governing store.
         # A non-timed mode such as Self Consumption Plus flips both enable
         # flags to 0 while keeping the configured windows stored.
+        grid_flag, dis_flag = charge["gridCharge"], discharge["ctrDis"]
         data[AlphaESSNames.TimeBasedControl] = (
-            int(charge["gridCharge"]) == 1 or int(discharge["ctrDis"]) == 1
+            None
+            if grid_flag is None and dis_flag is None
+            else int(grid_flag or 0) == 1 or int(dis_flag or 0) == 1
         )
 
     def _overlay_schedule_view(self, serial: str, data: dict[str, Any]) -> None:
@@ -1355,15 +1374,52 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             return False
         return self._legacy_state_from_data(self.data.get(serial) or {}) is not None
 
+    def set_periodic_enable_intent(
+        self, serial: str, *, grid_charge: int | None = None, ctr_dis: int | None = None
+    ) -> None:
+        """Record what the enable switches were last known to be set to.
+
+        Restored by the switch entities at startup: the API cannot report these,
+        so a value Home Assistant has never been told is a value it must not
+        invent.
+        """
+        intent = dict(self._periodic_enable_intent.get(serial) or {})
+        if grid_charge is not None:
+            intent["gridChargeCycle"] = int(grid_charge)
+        if ctr_dis is not None:
+            intent["ctrDisCycle"] = int(ctr_dis)
+        if intent:
+            # One switch may restore before the other; a half-filled record is
+            # still refused by _resolve_periodic_enable until it is complete.
+            self._periodic_enable_intent[serial] = intent
+
+    def _resolve_periodic_enable(
+        self,
+        serial: str,
+        charge: dict[str, Any] | None,
+        discharge: dict[str, Any] | None,
+    ) -> dict[str, int] | None:
+        """Return the enable pair to send, or None when it is not known.
+
+        This write wins over the stored intent; with neither, there is nothing
+        truthful to send and the caller must refuse rather than guess.
+        """
+        stored = self._periodic_enable_intent.get(serial) or {}
+        grid = (charge or {}).get("gridCharge", stored.get("gridChargeCycle"))
+        dis = (discharge or {}).get("ctrDis", stored.get("ctrDisCycle"))
+        if grid is None or dis is None:
+            return None
+        return {"gridChargeCycle": int(grid), "ctrDisCycle": int(dis)}
+
     def _committed_enable_flags(self, serial: str) -> tuple[int, int] | None:
         """Return the committed (gridCharge, ctrDis) flags of the governing
         store, or None while no store snapshot is available."""
         if self.is_periodic_schedule_readable(serial):
-            schedule = self._periodic_schedules[serial]
-            return (
-                int(schedule.get("gridChargeCycle", 1)),
-                int(schedule.get("ctrDisCycle", 1)),
-            )
+            intent = self._periodic_enable_intent.get(serial) or {}
+            grid, dis = intent.get("gridChargeCycle"), intent.get("ctrDisCycle")
+            if grid is None or dis is None:
+                return None
+            return (int(grid), int(dis))
         if self.is_legacy_backup_active(serial):
             cached = self._legacy_schedules.get(serial, {})
             if all(side in cached for side in ("charge", "discharge")):
@@ -1700,9 +1756,8 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             if not changes:
                 continue
 
-            cycle_field = spec["cycle_field"]
-            if cycle_field in changes:
-                proposed[spec["cycle"]] = int(changes[cycle_field])
+            # gridCharge/ctrDis are not part of the periodic resource; they
+            # are resolved separately and sent as their own parameters.
 
             list_key = spec["list"]
             original = proposed[list_key]
@@ -1821,9 +1876,11 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             if not periods:
                 raise ScheduleWriteError(
                     "setTimeChargeBySn requires at least one charge period and one "
-                    f"discharge period; {list_key} would be empty. Add a period to "
-                    "each side in the AlphaESS app, or stage both sides with the "
-                    "schedule entities and apply them together"
+                    f"discharge period; {list_key} would be empty (it answers 6001 "
+                    "for an empty list and 10001 for a missing one). To run one side "
+                    "only, give the other side a period and turn its switch off. Add "
+                    "a period to each side in the AlphaESS app, or stage both sides "
+                    "with the schedule entities and apply them together"
                 )
             for position, period in enumerate(periods, start=1):
                 # Name the offending period: it may be one the app created and
@@ -2007,7 +2064,21 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             now_window=now_window,
         )
 
-        if periodic_proposed == periodic_current:
+        enable = self._resolve_periodic_enable(serial, charge, discharge)
+        if enable is None:
+            raise ScheduleWriteError(
+                "Home Assistant does not know whether scheduled charging and "
+                "discharging should be enabled: getTimeChargeBySn reports 0 for "
+                "both whatever the inverter is doing, and sending that back would "
+                "switch it to self-consumption. Set the Scheduled Charging and "
+                "Scheduled Discharging switches once so there is something "
+                "truthful to send; nothing was written"
+            )
+
+        if (
+            periodic_proposed == periodic_current
+            and enable == self._periodic_enable_sent.get(serial)
+        ):
             _LOGGER.debug(
                 "Periodic schedule for %s already matches the requested values",
                 serial,
@@ -2016,18 +2087,13 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             return
 
         try:
-            kwargs = {
-                key: periodic_proposed[key]
-                for key in ("gridChargeCycle", "ctrDisCycle")
-                if key in periodic_proposed
-            }
             await self._call_cloud_api(
                 self.api.setTimeChargeBySn,
                 sysSn=serial,
                 executeCycleType=periodic_proposed["executeCycleType"],
                 chargeTimeList=periodic_proposed["chargeTimeList"],
                 dischargeTimeList=periodic_proposed["dischargeTimeList"],
-                **kwargs,
+                **enable,
             )
         except asyncio.CancelledError:
             raise
@@ -2067,6 +2133,8 @@ class AlphaESSDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
             ) from err
 
         self._periodic_schedules[serial] = deepcopy(periodic_proposed)
+        self._periodic_enable_intent[serial] = dict(enable)
+        self._periodic_enable_sent[serial] = dict(enable)
         _LOGGER.info(
             "Wrote periodic schedule for %s - charge: %s, discharge: %s",
             serial,

--- a/custom_components/alphaess/services.yaml
+++ b/custom_components/alphaess/services.yaml
@@ -9,7 +9,10 @@ setbatterycharge:
     period in the same schedule, so a one-sided call cannot initialise a
     completely empty schedule: create one period of each type in the
     AlphaESS app first, or stage both sides with the schedule entities and
-    Apply.
+    Apply. On periodic systems the Scheduled Charging and
+    Scheduled Discharging switches must both have been set once before any
+    call is accepted: AlphaESS never reports those two flags, and sending a
+    guess could switch the inverter to self-consumption.
   fields:
     serial:
       name: Serial
@@ -103,7 +106,10 @@ setbatterydischarge:
     discharge period in the same schedule, so a one-sided call cannot
     initialise a completely empty schedule: create one period of each type
     in the AlphaESS app first, or stage both sides with the schedule
-    entities and Apply.
+    entities and Apply. On periodic systems the Scheduled Charging and
+    Scheduled Discharging switches must both have been set once before any
+    call is accepted: AlphaESS never reports those two flags, and sending a
+    guess could switch the inverter to self-consumption.
   fields:
     serial:
       name: Serial

--- a/custom_components/alphaess/switch.py
+++ b/custom_components/alphaess/switch.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -103,6 +104,10 @@ class AlphaSwitch(CoordinatorEntity, SwitchEntity):
 
     async def _set_value(self, value: int) -> None:
         """Stage the updated flag for the atomic Apply Schedule action."""
+        if self._coordinator.can_unlock_time_controls(self._serial):
+            await self._async_write_unlock(value)
+            return
+
         previous_state = self._optimistic_state
         self._optimistic_state = bool(value)
         self.async_write_ha_state()
@@ -127,6 +132,41 @@ class AlphaSwitch(CoordinatorEntity, SwitchEntity):
         # The coordinator overlays the draft on subsequent polls so the value
         # stays visible until it is applied or discarded.
 
+    async def _async_write_unlock(self, value: int) -> None:
+        """Send an enable immediately while the schedule surface is locked.
+
+        Nothing else can be staged or applied in that state, so a draft here
+        would only wait behind an Apply button that is itself unavailable.
+        """
+        if value != 1:
+            raise HomeAssistantError(
+                f"Both timers for {self._serial} are already off. Switching one "
+                "back on is the only schedule change Home Assistant can make "
+                "while the inverter reports no timed control; the working mode "
+                "can only be changed in the AlphaESS app"
+            )
+
+        previous_state = self._optimistic_state
+        self._optimistic_state = True
+        self.async_write_ha_state()
+        try:
+            if self._coordinator_key == "gridCharge":
+                await self._coordinator.async_write_charge_config(
+                    self._serial, grid_charge=1,
+                )
+            else:
+                await self._coordinator.async_write_discharge_config(
+                    self._serial, ctr_dis=1,
+                )
+        except Exception:
+            _LOGGER.exception(
+                "Failed to re-enable %s for %s, reverting",
+                self._coordinator_key, self._serial,
+            )
+            self._optimistic_state = previous_state
+            self.async_write_ha_state()
+            raise
+
     @property
     def available(self) -> bool:
         """Switch controls require the cloud API, a usable schedule store,
@@ -142,9 +182,11 @@ class AlphaSwitch(CoordinatorEntity, SwitchEntity):
             or self._serial not in self._coordinator.data
         ):
             return False
-        return (
-            self._coordinator.cloud_available
-            and self._coordinator.can_modify_time_controls(self._serial)
+        return self._coordinator.cloud_available and (
+            self._coordinator.can_modify_time_controls(self._serial)
+            # The one exception to the lockout: with both timers off, these
+            # switches are the only way back to a timed mode from here.
+            or self._coordinator.can_unlock_time_controls(self._serial)
         )
 
     @property

--- a/custom_components/alphaess/switch.py
+++ b/custom_components/alphaess/switch.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -60,8 +61,15 @@ async def async_setup_entry(hass, entry, async_add_entities) -> None:
             )
 
 
-class AlphaSwitch(CoordinatorEntity, SwitchEntity):
-    """Switch entity for grid charge / discharge time control."""
+class AlphaSwitch(CoordinatorEntity, RestoreEntity, SwitchEntity):
+    """Switch entity for grid charge / discharge time control.
+
+    On the periodic store these two switches are the only record of whether
+    scheduled charging and discharging should be on: getTimeChargeBySn answers
+    0 for both however the inverter is set, so the state published here is
+    restored on startup and handed back to the coordinator, which needs it to
+    build any write at all.
+    """
 
     def __init__(self, coordinator, serial, config, description, device_info=None):
         super().__init__(coordinator)
@@ -93,6 +101,24 @@ class AlphaSwitch(CoordinatorEntity, SwitchEntity):
         """Clear optimistic state when coordinator provides fresh data."""
         self._optimistic_state = None
         super()._handle_coordinator_update()
+
+    async def async_added_to_hass(self) -> None:
+        """Hand the last published state back as the recorded answer."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state not in ("on", "off"):
+            return
+        value = 1 if last_state.state == "on" else 0
+        if self._coordinator_key == "gridCharge":
+            self._coordinator.set_periodic_enable_intent(
+                self._serial, grid_charge=value,
+            )
+        else:
+            self._coordinator.set_periodic_enable_intent(self._serial, ctr_dis=value)
+        _LOGGER.debug(
+            "Restored %s=%s for %s from the last published state",
+            self._coordinator_key, value, self._serial,
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on (enable) the setting."""

--- a/tests/test_button_number.py
+++ b/tests/test_button_number.py
@@ -115,7 +115,10 @@ def _periodic_schedule() -> dict:
 def _seed_periodic_schedule(coordinator) -> None:
     coordinator.data = {SERIAL: _complete_schedule_data()}
     coordinator._periodic_readable[SERIAL] = True
-    coordinator._periodic_schedules[SERIAL] = _periodic_schedule()
+    coordinator._periodic_schedules[SERIAL] = (
+        coordinator._normalise_periodic_schedule(_periodic_schedule())
+    )
+    coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=1)
     coordinator._publish_schedule_view(SERIAL)
 
 

--- a/tests/test_coordinator_polling.py
+++ b/tests/test_coordinator_polling.py
@@ -250,6 +250,7 @@ class TestChargeDischargeCommands:
         coordinator = make_coordinator()
         coordinator.set_number_setting(SERIAL, "batUseCap", 15)
         coordinator.data = {SERIAL: {}}
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=1)
         periodic = _periodic_schedule()
         mock_api.getTimeChargeBySn.return_value = periodic
 
@@ -294,6 +295,7 @@ class TestChargeDischargeCommands:
         coordinator = make_coordinator()
         coordinator.set_number_setting(SERIAL, "batHighCap", 85)
         coordinator.data = {SERIAL: {}}
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=1)
         periodic = _periodic_schedule()
         mock_api.getTimeChargeBySn.return_value = periodic
 
@@ -335,6 +337,7 @@ class TestChargeDischargeCommands:
     async def test_update_charge_serial_missing(self, make_coordinator, mock_api):
         coordinator = make_coordinator()
         coordinator.data = {}
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=1)
         mock_api.getTimeChargeBySn.return_value = _periodic_schedule()
 
         await coordinator.update_charge("batHighCap", SERIAL, 60)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -362,6 +362,7 @@ class TestServices:
     async def test_battery_charge_service(self, mock_hass, make_coordinator, mock_api):
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: {}}
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=1)
         periodic = _periodic_schedule()
         mock_api.getTimeChargeBySn.return_value = periodic
         entry = FakeEntry()
@@ -395,6 +396,7 @@ class TestServices:
     async def test_battery_discharge_service(self, mock_hass, make_coordinator, mock_api):
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: {}}
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=1)
         periodic = _periodic_schedule()
         mock_api.getTimeChargeBySn.return_value = periodic
         entry = FakeEntry()

--- a/tests/test_periodic_schedule.py
+++ b/tests/test_periodic_schedule.py
@@ -160,6 +160,19 @@ def _schedule_data() -> dict:
     return _entity_data(_legacy_charge(), _legacy_discharge())
 
 
+def _cached(schedule: dict) -> dict:
+    """Return the form a read leaves in the cache.
+
+    gridChargeCycle/ctrDisCycle are write-only (the endpoint answers 0 for both
+    however the inverter is set), so the snapshot never carries them.
+    """
+    return {
+        key: deepcopy(value)
+        for key, value in schedule.items()
+        if key not in ("gridChargeCycle", "ctrDisCycle")
+    }
+
+
 def _seed(
     coordinator,
     *,
@@ -178,7 +191,23 @@ def _seed(
     discharge = deepcopy(discharge or _legacy_discharge())
     coordinator.data = {SERIAL: _entity_data(charge, discharge, poinv=poinv)}
     if periodic is not None:
-        coordinator._periodic_schedules[SERIAL] = deepcopy(periodic)
+        # The cache always holds the normalised resource, exactly as a real read
+        # leaves it: gridChargeCycle/ctrDisCycle are write-only and stripped.
+        coordinator._periodic_schedules[SERIAL] = (
+            coordinator._normalise_periodic_schedule(deepcopy(periodic))
+        )
+        # The flags a test puts in the payload express what the user last asked
+        # for, which is the only place that answer can come from now.
+        coordinator.set_periodic_enable_intent(
+            SERIAL,
+            grid_charge=periodic.get("gridChargeCycle", 1),
+            ctr_dis=periodic.get("ctrDisCycle", 1),
+        )
+        # ...and has already sent it once, so a write that changes nothing
+        # still has nothing to say.
+        coordinator._periodic_enable_sent[SERIAL] = dict(
+            coordinator._periodic_enable_intent[SERIAL]
+        )
     if readable is not None:
         coordinator._periodic_readable[SERIAL] = readable
     return coordinator
@@ -675,7 +704,7 @@ class TestEndpointOutcomes:
             await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
 
         mock_api.updateChargeConfigInfo.assert_not_awaited()
-        assert coordinator._periodic_schedules[SERIAL] == periodic
+        assert coordinator._periodic_schedules[SERIAL] == _cached(periodic)
         assert "generic set-failed" in caplog.text
         assert "one possible cause" in caplog.text
 
@@ -725,7 +754,7 @@ class TestRefresh:
         await coordinator._async_resolve_unknown_periodic_read()
 
         mock_api.getTimeChargeBySn.assert_awaited_once_with(SERIAL)
-        assert coordinator._periodic_schedules[SERIAL] == changed
+        assert coordinator._periodic_schedules[SERIAL] == _cached(changed)
         assert coordinator.data[SERIAL]["charge_timeChaf1"] == "02:00"
         assert coordinator.data[SERIAL]["charge_timeChae1"] == "06:00"
 
@@ -763,3 +792,110 @@ class TestRefresh:
         mock_api.setTimeChargeBySn.assert_not_awaited()
         mock_api.updateChargeConfigInfo.assert_not_awaited()
         mock_api.updateDisChargeConfigInfo.assert_not_awaited()
+
+
+class TestWriteOnlyEnableFlags:
+    """gridChargeCycle/ctrDisCycle are write-only. getTimeChargeBySn answers 0
+    for both whatever the inverter is doing, and setTimeChargeBySn acts on
+    them — 0/0 switches the inverter to self-consumption. Echoing the read back
+    therefore turns timed control off on every write (#267)."""
+
+    def test_the_read_never_becomes_part_of_the_snapshot(self, make_coordinator):
+        coordinator = make_coordinator()
+        payload = _daily_schedule()
+        payload["gridChargeCycle"] = 0
+        payload["ctrDisCycle"] = 0
+
+        normalised = coordinator._normalise_periodic_schedule(payload)
+
+        assert "gridChargeCycle" not in normalised
+        assert "ctrDisCycle" not in normalised
+
+    async def test_a_write_sends_what_was_asked_for_not_what_was_read(
+        self, make_coordinator, mock_api
+    ):
+        """The regression: a system reporting 0/0 while running a schedule must
+        not have those zeros posted back at it."""
+        periodic = _daily_schedule()
+        coordinator = _seed(make_coordinator(), periodic=periodic, readable=True)
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=0)
+        answered = deepcopy(periodic)
+        answered["gridChargeCycle"] = 0
+        answered["ctrDisCycle"] = 0
+        mock_api.getTimeChargeBySn.return_value = answered
+
+        await coordinator.async_write_charge_config(
+            SERIAL, times={"timeChaf1": "02:00"}
+        )
+
+        payload = _periodic_payload(mock_api)
+        assert payload["gridChargeCycle"] == 1
+        assert payload["ctrDisCycle"] == 0
+
+    async def test_a_switch_change_wins_over_the_stored_answer(
+        self, make_coordinator, mock_api
+    ):
+        periodic = _daily_schedule()
+        coordinator = _seed(make_coordinator(), periodic=periodic, readable=True)
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=0, ctr_dis=0)
+        mock_api.getTimeChargeBySn.return_value = deepcopy(periodic)
+
+        await coordinator.async_write_discharge_config(SERIAL, ctr_dis=1)
+
+        payload = _periodic_payload(mock_api)
+        assert payload["gridChargeCycle"] == 0
+        assert payload["ctrDisCycle"] == 1
+        # And it becomes the answer the next write starts from.
+        assert coordinator._periodic_enable_intent[SERIAL] == {
+            "gridChargeCycle": 0,
+            "ctrDisCycle": 1,
+        }
+
+    async def test_a_write_is_refused_while_the_answer_is_unknown(
+        self, make_coordinator, mock_api
+    ):
+        """Nothing in the API can supply it, so guessing would mean choosing
+        the inverter's working mode on the user's behalf."""
+        periodic = _daily_schedule()
+        coordinator = _seed(make_coordinator(), periodic=periodic, readable=True)
+        coordinator._periodic_enable_intent.pop(SERIAL, None)
+        mock_api.getTimeChargeBySn.return_value = deepcopy(periodic)
+
+        with pytest.raises(ScheduleWriteError, match="does not know whether"):
+            await coordinator.async_write_charge_config(
+                SERIAL, times={"timeChaf1": "02:00"}
+            )
+
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+
+    async def test_one_sided_knowledge_is_still_not_an_answer(
+        self, make_coordinator, mock_api
+    ):
+        """Both parameters go in every request, so half a record cannot fill
+        one in."""
+        periodic = _daily_schedule()
+        coordinator = _seed(make_coordinator(), periodic=periodic, readable=True)
+        coordinator._periodic_enable_intent[SERIAL] = {"gridChargeCycle": 1}
+        mock_api.getTimeChargeBySn.return_value = deepcopy(periodic)
+
+        with pytest.raises(ScheduleWriteError, match="does not know whether"):
+            await coordinator.async_write_discharge_config(
+                SERIAL, times={"timeDisf1": "18:00"}
+            )
+
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+
+    async def test_a_flag_only_change_still_reaches_the_api(
+        self, make_coordinator, mock_api
+    ):
+        """The periods are identical, but the flags are the whole point of the
+        request and the endpoint cannot be asked about them separately."""
+        periodic = _daily_schedule()
+        coordinator = _seed(make_coordinator(), periodic=periodic, readable=True)
+        mock_api.getTimeChargeBySn.return_value = deepcopy(periodic)
+
+        await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
+
+        payload = _periodic_payload(mock_api)
+        assert payload["gridChargeCycle"] == 0
+        assert payload["chargeTimeList"] == _cached(periodic)["chargeTimeList"]

--- a/tests/test_platform_entities.py
+++ b/tests/test_platform_entities.py
@@ -1,9 +1,12 @@
 """Tests for binary_sensor, switch and time platforms."""
+from copy import deepcopy
 from datetime import time as dt_time
 from unittest.mock import MagicMock
 
 import pytest
+from alphaess.alphaess import AlphaESSApiError
 from homeassistant.config_entries import ConfigSubentry
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.alphaess.binary_sensor import (
     AlphaEVReadinessBinarySensor,
@@ -754,10 +757,10 @@ class TestSelfConsumptionLockout:
             )
         assert not coordinator.has_schedule_draft(SERIAL)
 
-    def test_switch_staging_is_refused_too(self, make_coordinator):
-        """Field-tested: writing an enable flag does not leave a
-        self-consumption mode, so even the switches are locked — the working
-        mode is app-authority only."""
+    def test_an_enable_flag_still_cannot_be_staged(self, make_coordinator):
+        """A draft is the wrong shape for the escape hatch: Apply is locked
+        too, so a staged enable would sit there unsendable. The switch sends
+        it immediately instead — see TestUnlockingFromTheSwitch."""
         from custom_components.alphaess.coordinator import ScheduleWriteError
 
         coordinator = self._seed_self_consumption(make_coordinator())
@@ -793,15 +796,23 @@ class TestSelfConsumptionLockout:
         with pytest.raises(ScheduleWriteError, match="last enabled timer"):
             coordinator.stage_schedule_change(SERIAL, charge={"gridCharge": 0})
 
-    async def test_services_are_locked_too(self, make_coordinator, mock_api):
+    async def test_a_write_that_carries_more_than_an_enable_is_refused(
+        self, make_coordinator, mock_api
+    ):
+        """Windows, cutoffs and powers still cannot be written into a store
+        whose working mode cannot be read."""
         from custom_components.alphaess.coordinator import ScheduleWriteError
 
         coordinator = self._seed_self_consumption(make_coordinator())
 
-        with pytest.raises(ScheduleWriteError, match="self-consumption"):
-            await coordinator.async_write_charge_config(SERIAL, grid_charge=1)
-        with pytest.raises(ScheduleWriteError, match="self-consumption"):
-            await coordinator.async_write_discharge_config(SERIAL, ctr_dis=1)
+        with pytest.raises(ScheduleWriteError, match="both timers are switched"):
+            await coordinator.async_write_charge_config(
+                SERIAL, grid_charge=1, times={"timeChaf1": "02:00"}
+            )
+        with pytest.raises(ScheduleWriteError, match="both timers are switched"):
+            await coordinator.async_write_discharge_config(SERIAL, bat_use_cap=15)
+        with pytest.raises(ScheduleWriteError, match="both timers are switched"):
+            await coordinator.async_write_charge_config(SERIAL, grid_charge=0)
 
         mock_api.setTimeChargeBySn.assert_not_awaited()
         mock_api.updateChargeConfigInfo.assert_not_awaited()
@@ -896,7 +907,10 @@ class TestSelfConsumptionLockout:
 
         assert time_entity.available is False
         assert soc_entity.available is False
-        assert switch.available is False  # app-authority: no way back from HA
+        # The switches stay live: they are the only way back to a timed mode
+        # without opening the AlphaESS app.
+        assert switch.available is True
+        assert coordinator.can_unlock_time_controls(SERIAL) is True
 
         # Re-enabling in the app unlocks everything: mimic a full poll,
         # which refreshes the legacy cache before overlaying.
@@ -918,7 +932,105 @@ class TestSelfConsumptionLockout:
 
         assert coordinator.is_time_based_control_active(SERIAL) is False
         assert coordinator.can_modify_time_controls(SERIAL) is False
-        assert coordinator.can_stage_schedule(SERIAL) is True  # switches live
+        assert coordinator.can_stage_schedule(SERIAL) is True
+        assert coordinator.can_unlock_time_controls(SERIAL) is True
+
+
+class TestUnlockingFromTheSwitch:
+    """Both flags at 0 is either self-consumption or simply both timers off,
+    and the OpenAPI cannot tell them apart. Switching one back on is the one
+    write that is safe under either reading, so it stays possible."""
+
+    def _seed_locked(self, coordinator, mock_api):
+        coordinator.data = {SERIAL: _complete_schedule_data()}
+        _seed_periodic(coordinator)
+        schedule = coordinator._periodic_schedules[SERIAL]
+        schedule["gridChargeCycle"] = 0
+        schedule["ctrDisCycle"] = 0
+        coordinator._overlay_schedule_view(SERIAL, coordinator.data[SERIAL])
+        mock_api.getTimeChargeBySn.return_value = deepcopy(schedule)
+        return coordinator
+
+    def _switch(self, coordinator, coordinator_key="gridCharge"):
+        description = next(
+            d for d in CHARGE_DISCHARGE_SWITCHES
+            if d.coordinator_key == coordinator_key
+        )
+        switch = AlphaSwitch(coordinator, SERIAL, FakeEntry(), description)
+        switch.async_write_ha_state = MagicMock()
+        return switch
+
+    async def test_turning_a_timer_on_writes_immediately_and_unlocks(
+        self, make_coordinator, mock_api
+    ):
+        coordinator = self._seed_locked(make_coordinator(), mock_api)
+        before = deepcopy(coordinator._periodic_schedules[SERIAL])
+        switch = self._switch(coordinator)
+
+        await switch.async_turn_on()
+
+        payload = mock_api.setTimeChargeBySn.await_args.kwargs
+        assert payload["gridChargeCycle"] == 1
+        # Nothing but the flag moves: the periods are sent back untouched.
+        assert payload["chargeTimeList"] == before["chargeTimeList"]
+        assert payload["dischargeTimeList"] == before["dischargeTimeList"]
+        # It is an immediate action, so there is no draft waiting on an Apply
+        # button that would itself have been unavailable.
+        assert not coordinator.has_schedule_draft(SERIAL)
+        assert coordinator.is_time_based_control_active(SERIAL) is True
+        assert coordinator.can_modify_time_controls(SERIAL) is True
+
+    async def test_the_discharge_switch_unlocks_the_same_way(
+        self, make_coordinator, mock_api
+    ):
+        coordinator = self._seed_locked(make_coordinator(), mock_api)
+        switch = self._switch(coordinator, "ctrDis")
+
+        await switch.async_turn_on()
+
+        assert mock_api.setTimeChargeBySn.await_args.kwargs["ctrDisCycle"] == 1
+        assert coordinator.is_time_based_control_active(SERIAL) is True
+
+    async def test_turning_one_off_from_here_is_still_refused(
+        self, make_coordinator, mock_api
+    ):
+        """Both are already off; the only reading under which this means
+        anything is the one HA cannot verify."""
+        coordinator = self._seed_locked(make_coordinator(), mock_api)
+        switch = self._switch(coordinator)
+
+        with pytest.raises(HomeAssistantError, match="already off"):
+            await switch.async_turn_off()
+
+        mock_api.setTimeChargeBySn.assert_not_awaited()
+        assert switch.is_on is False
+
+    async def test_a_rejected_unlock_puts_the_switch_back(
+        self, make_coordinator, mock_api
+    ):
+        coordinator = self._seed_locked(make_coordinator(), mock_api)
+        mock_api.setTimeChargeBySn.side_effect = AlphaESSApiError(
+            code=6008, description="Set failed"
+        )
+        switch = self._switch(coordinator)
+
+        with pytest.raises(HomeAssistantError):
+            await switch.async_turn_on()
+
+        assert switch.is_on is False
+        assert coordinator.is_time_based_control_active(SERIAL) is False
+
+    def test_an_unreadable_store_leaves_the_switch_unavailable(
+        self, make_coordinator
+    ):
+        """No usable snapshot is a different failure: there is nothing to
+        raise a flag on, so the switch stays gone rather than offering a
+        write that cannot be built."""
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: {"Model": "SMILE5-INV"}}
+
+        assert coordinator.can_unlock_time_controls(SERIAL) is False
+        assert self._switch(coordinator).available is False
 
 
 class TestUnsetSlotDisplay:

--- a/tests/test_platform_entities.py
+++ b/tests/test_platform_entities.py
@@ -1,7 +1,8 @@
 """Tests for binary_sensor, switch and time platforms."""
 from copy import deepcopy
 from datetime import time as dt_time
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from alphaess.alphaess import AlphaESSApiError
@@ -62,7 +63,8 @@ def _complete_schedule_data() -> dict:
 def _seed_periodic(coordinator) -> None:
     """Give schedule controls their only live store: the periodic API."""
     coordinator._periodic_readable[SERIAL] = True
-    coordinator._periodic_schedules[SERIAL] = {
+    coordinator.set_periodic_enable_intent(SERIAL, grid_charge=1, ctr_dis=1)
+    coordinator._periodic_schedules[SERIAL] = coordinator._normalise_periodic_schedule({
         "executeCycleType": 0,
         "gridChargeCycle": 1,
         "ctrDisCycle": 1,
@@ -82,7 +84,7 @@ def _seed_periodic(coordinator) -> None:
                 "chargePower": 2500,
             }
         ],
-    }
+    })
 
 
 def _inverter_subentry(serial=SERIAL, model="SMILE5-INV"):
@@ -677,21 +679,31 @@ class TestTimeBasedControlBinarySensor:
         entity = self._make(coordinator)
         assert entity.is_on is True
 
-    def test_follows_periodic_cycle_flags(self, make_coordinator):
+    def test_follows_the_recorded_periodic_intent(self, make_coordinator):
+        """getTimeChargeBySn answers 0 for both flags whatever the inverter is
+        doing, so on the primary store the only answer available is the one
+        Home Assistant was given."""
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: {"Model": "SMILE5-INV"}}
         _seed_periodic(coordinator)
-        schedule = coordinator._periodic_schedules[SERIAL]
-        schedule["gridChargeCycle"] = 0
-        schedule["ctrDisCycle"] = 0
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=0, ctr_dis=0)
         coordinator._overlay_schedule_view(SERIAL, coordinator.data[SERIAL])
 
         entity = self._make(coordinator)
         assert entity.is_on is False
 
-        schedule["ctrDisCycle"] = 1
+        coordinator.set_periodic_enable_intent(SERIAL, ctr_dis=1)
         coordinator._overlay_schedule_view(SERIAL, coordinator.data[SERIAL])
         assert entity.is_on is True
+
+    def test_unknown_until_home_assistant_has_been_told(self, make_coordinator):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: {"Model": "SMILE5-INV"}}
+        _seed_periodic(coordinator)
+        coordinator._periodic_enable_intent.pop(SERIAL, None)
+        coordinator._overlay_schedule_view(SERIAL, coordinator.data[SERIAL])
+
+        assert self._make(coordinator).is_on is None
 
     def test_unavailable_without_a_schedule_store(self, make_coordinator):
         """Unknown mode has nothing truthful to report."""
@@ -921,19 +933,88 @@ class TestSelfConsumptionLockout:
         assert soc_entity.available is True
         assert switch.available is True
 
-    def test_periodic_mode_locks_the_same_way(self, make_coordinator):
+    def test_periodic_mode_locks_only_on_a_recorded_choice(self, make_coordinator):
+        """Asking for both timers off is a real request on the primary store —
+        it is how the API is told to run self-consumption — so it locks. What
+        the endpoint echoes back is not, and must not."""
         coordinator = make_coordinator()
         coordinator.data = {SERIAL: {"Model": "SMILE5-INV"}}
         _seed_periodic(coordinator)
-        schedule = coordinator._periodic_schedules[SERIAL]
-        schedule["gridChargeCycle"] = 0
-        schedule["ctrDisCycle"] = 0
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=0, ctr_dis=0)
         coordinator._overlay_schedule_view(SERIAL, coordinator.data[SERIAL])
 
         assert coordinator.is_time_based_control_active(SERIAL) is False
         assert coordinator.can_modify_time_controls(SERIAL) is False
         assert coordinator.can_stage_schedule(SERIAL) is True
         assert coordinator.can_unlock_time_controls(SERIAL) is True
+
+    def test_periodic_mode_does_not_lock_on_an_unanswered_question(
+        self, make_coordinator
+    ):
+        """Before anything has been recorded there is no basis to lock: the
+        endpoint's 0/0 says nothing about the inverter."""
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: {"Model": "SMILE5-INV"}}
+        _seed_periodic(coordinator)
+        coordinator._periodic_enable_intent.pop(SERIAL, None)
+        coordinator._overlay_schedule_view(SERIAL, coordinator.data[SERIAL])
+
+        assert coordinator.is_time_based_control_active(SERIAL) is None
+        assert coordinator.can_modify_time_controls(SERIAL) is True
+
+
+class TestSwitchStateSurvivesRestart:
+    """The switches carry the only record of the enable flags, so the state
+    they publish has to come back with them."""
+
+    def _switch(self, coordinator, coordinator_key="gridCharge"):
+        description = next(
+            d for d in CHARGE_DISCHARGE_SWITCHES
+            if d.coordinator_key == coordinator_key
+        )
+        switch = AlphaSwitch(coordinator, SERIAL, FakeEntry(), description)
+        switch.async_write_ha_state = MagicMock()
+        return switch
+
+    @pytest.mark.parametrize(
+        ("state", "expected"), [("on", 1), ("off", 0)],
+    )
+    async def test_the_last_published_state_becomes_the_recorded_answer(
+        self, make_coordinator, state, expected
+    ):
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _complete_schedule_data()}
+        _seed_periodic(coordinator)
+        coordinator._periodic_enable_intent.pop(SERIAL, None)
+
+        for key, restored in (("gridCharge", state), ("ctrDis", "on")):
+            switch = self._switch(coordinator, key)
+            switch.async_get_last_state = AsyncMock(
+                return_value=SimpleNamespace(state=restored)
+            )
+            await switch.async_added_to_hass()
+
+        assert coordinator._periodic_enable_intent[SERIAL] == {
+            "gridChargeCycle": expected,
+            "ctrDisCycle": 1,
+        }
+
+    @pytest.mark.parametrize("restored", [None, SimpleNamespace(state="unknown")])
+    async def test_nothing_usable_leaves_the_question_open(
+        self, make_coordinator, restored
+    ):
+        """A first install, or a state that was never published, must not be
+        read as an answer — writes refuse instead."""
+        coordinator = make_coordinator()
+        coordinator.data = {SERIAL: _complete_schedule_data()}
+        _seed_periodic(coordinator)
+        coordinator._periodic_enable_intent.pop(SERIAL, None)
+
+        switch = self._switch(coordinator)
+        switch.async_get_last_state = AsyncMock(return_value=restored)
+        await switch.async_added_to_hass()
+
+        assert SERIAL not in coordinator._periodic_enable_intent
 
 
 class TestUnlockingFromTheSwitch:
@@ -944,11 +1025,11 @@ class TestUnlockingFromTheSwitch:
     def _seed_locked(self, coordinator, mock_api):
         coordinator.data = {SERIAL: _complete_schedule_data()}
         _seed_periodic(coordinator)
-        schedule = coordinator._periodic_schedules[SERIAL]
-        schedule["gridChargeCycle"] = 0
-        schedule["ctrDisCycle"] = 0
+        coordinator.set_periodic_enable_intent(SERIAL, grid_charge=0, ctr_dis=0)
         coordinator._overlay_schedule_view(SERIAL, coordinator.data[SERIAL])
-        mock_api.getTimeChargeBySn.return_value = deepcopy(schedule)
+        mock_api.getTimeChargeBySn.return_value = deepcopy(
+            coordinator._periodic_schedules[SERIAL]
+        )
         return coordinator
 
     def _switch(self, coordinator, coordinator_key="gridCharge"):

--- a/tests/test_schedule_edge_coverage.py
+++ b/tests/test_schedule_edge_coverage.py
@@ -38,6 +38,7 @@ from .conftest import FakeEntry
 from .test_periodic_schedule import (
     SERIAL,
     _api_error,
+    _cached,
     _daily_schedule,
     _entity_data,
     _legacy_charge,
@@ -249,7 +250,7 @@ class TestDraftEdges:
 
         coordinator.discard_schedule_draft(SERIAL)
 
-        assert coordinator._periodic_schedules[SERIAL] == changed_remotely
+        assert coordinator._periodic_schedules[SERIAL] == _cached(changed_remotely)
         assert coordinator.data[SERIAL]["charge_timeChae1"] == "04:30"
         mock_api.setTimeChargeBySn.assert_not_awaited()
 
@@ -534,7 +535,7 @@ class TestIdempotentDraftRetry:
         )
 
         mock_api.setTimeChargeBySn.assert_not_awaited()
-        assert coordinator._periodic_schedules[SERIAL] == accepted
+        assert coordinator._periodic_schedules[SERIAL] == _cached(accepted)
 
     async def test_unknown_outcome_apply_keeps_draft_until_base_is_refreshed(
         self, make_coordinator, mock_api
@@ -576,7 +577,7 @@ class TestIdempotentDraftRetry:
 
         mock_api.setTimeChargeBySn.assert_not_awaited()
         assert not coordinator.has_schedule_draft(SERIAL)
-        assert coordinator._periodic_schedules[SERIAL] == accepted
+        assert coordinator._periodic_schedules[SERIAL] == _cached(accepted)
 
 
 class TestTimedButtonUncertainOutcome:


### PR DESCRIPTION
Follow-up to #274, from testing on #267. Two commits: the second is the important one.

## What #267 turned up

@dragon2611 probed `setTimeChargeBySn` directly and established what the two enable flags actually do:

| sent | effect on the inverter |
| --- | --- |
| `1 / 0` | schedule active, scheduled discharging off |
| `1 / 1` | both schedules enabled |
| `0 / 1` | scheduled discharging only |
| `0 / 0` | **switches the inverter to self-consumption** |

And that `getTimeChargeBySn` answers `0` for both however the inverter is set — he wrote `1` and read back `0` half a minute later, across a schedule rewrite, a switch to Self-Consumption and a switch back to Time-Based Control. **They are write-only.**

## The bug that follows

`main` reads those flags, keeps them in the snapshot, and sends them back on every write. On a system whose read is always `0/0` that means **every schedule change Home Assistant makes posts `0/0` and asks the inverter to leave timed control.** The lockout then reads the same zeros and reports a self-consumption mode — which by then is true, because we put it there.

The only thing that kept it from being worse is the bug that hid it: with the read always `0/0`, `is_time_based_control_active()` is always False, so the lockout refused every write. It jammed far more often than it fired. Removing either half on its own makes things worse, so both are fixed here.

## The fix

- **The read is no longer part of the snapshot.** Nothing can replay it.
- **Every write sends a value that came from the user** — this request first, then what was last recorded — and is **refused** when neither has an answer, rather than choosing a working mode on someone's behalf.
- **The two switches are the record.** They restore their published state on startup and hand it back to the coordinator, and read **unknown** rather than `off` until they have one.
- **A recorded `0/0` is a real request** — it is how the API is told to run self-consumption — so it still locks the time-based controls, and the switches stay available to undo it (that is the first commit).
- **Backup mode is untouched.** There `gridCharge`/`ctrDis` are ordinary read-write fields, live-probed in #274, and behave exactly as before.

Also confirmed from his probes: an empty period list answers `6001` and a missing one `10001`, so the both-lists rule stands — and the error now names the workaround, which is to give the side you don't want a period and turn its switch off.

## Consequence worth flagging

`setbatterycharge` carries only the charge flag, so on periodic systems both switches must be set once before any service call is accepted. Documented in `services.yaml` and in the Predbat section of the README.

## Tests

554 → 568, 100% coverage, ruff clean. `TestWriteOnlyEnableFlags` pins the regression directly: a system answering `0/0` while running a schedule gets `1/0` posted back, not the zeros. Plus a switch change beating the stored answer, refusal on unknown and half-known state, a flag-only change still reaching the API, and the normaliser stripping the read. `TestSwitchStateSurvivesRestart` covers restoration.
